### PR TITLE
create addTeamToRepository method to OrganizationApi.js

### DIFF
--- a/lib/github/OrganizationApi.js
+++ b/lib/github/OrganizationApi.js
@@ -193,4 +193,20 @@ util.inherits(OrganizationApi, AbstractApi);
         );
     };
 
+    /**
+     *
+     * Add a team to a repo
+     * @param {String} teamId
+     * @param {String} username
+     * @param {String} repo
+     */
+     this.addTeamToRepository = function(teamId, username, repo, callback)
+     {
+         var parameters = { name: username + '/' + repo };
+         this.$api.post(
+             'teams/' + encodeURI(teamId) + '/repositories?name=' + encodeURI(username) + '/' + encodeURI(repo),
+             null, null,
+             this.$createListener(callback, "team")
+         );
+     };
 }).call(OrganizationApi.prototype);

--- a/lib/github/OrganizationApiTest.js
+++ b/lib/github/OrganizationApiTest.js
@@ -123,6 +123,15 @@ var test = module.exports = {
             });
         });
     },
+    
+    "!test: add a team to a repo" : function(finished) {
+        this.github.authenticateToken(username, token);
+        this.organizationApi.addTeamToRepository(teamId, username, repo, function(err, response) {
+            console.log(response);
+            assert.equal(err, null);
+            finished(); 
+        });
+    }
 };
 
 !module.parent && require("asyncjs").test.testcase(module.exports).exec();


### PR DESCRIPTION
I had the need to add a team to a github repo so I added a method to OrganizationApi to do so. I also added a test but left it disabled since you'll need to be able to create a repo, and have rights to add a team to it, in order for the test to run.
