### PR TITLE
Add paging to the API

### DIFF
--- a/lib/github/CommitApi.js
+++ b/lib/github/CommitApi.js
@@ -25,13 +25,23 @@ util.inherits(CommitApi, AbstractApi);
      *
      * @param {String}  username         the username
      * @param {String}  repo             the repo
-     * @param {String}  $branch           the branch
+     * @param {String}  $branch          the branch
+     * @param {Number}  page             the page number of the commit (optional)
      */
-    this.getBranchCommits = function(username, repo, branch, callback)
+    this.getBranchCommits = function(username, repo, branch, page, callback)
     {
+        var pageNumber;
+        if (typeof page === 'function') {
+            pageNumber = "1";
+            callback = page;
+        }
+        else {
+            pageNumber = page.toString();
+        }
+
         this.$api.get(
             'commits/list/' + encodeURI(username) + "/" + encodeURI(repo) + "/" + encodeURI(branch),
-            null, null,
+            {"page" : pageNumber}, null,
             this.$createListener(callback, "commits")
         );
     };


### PR DESCRIPTION
The official GitHub API says to pass in a page number to retrieve that "set" of commits: http://develop.github.com/p/commits.html

This is analogous to the GitHub API. Unfortunately, this is not supported in this library, nor, apparently, the PHP library.

So here it is. And I need this. :)

The header object **must** be a string, as I found out the hard way; in other words, `{"page": 2}` will not work. The API function takes in a number, because it's a stronger user case. The user might be doing a `for` loop, and can just pass the numeral into `getBranchCommits()`.

@mattpardee  @fjakobs 
