### PR TITLE
Required Parameters Are Not In Fact Required

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -638,7 +638,7 @@
                 "$repo": null,
                 "milestone": {
                     "type": "String",
-                    "required": true,
+                    "required": false,
                     "validation": "^([0-9]+|none|\\*)$",
                     "invalidmsg": "",
                     "description": ""
@@ -646,7 +646,7 @@
                 "$state": null,
                 "assignee": {
                     "type": "String",
-                    "required": true,
+                    "required": false,
                     "validation": "",
                     "invalidmsg": "String User login, `none` for Issues with no assigned User. `*` for Issues with any assigned User.",
                     "description": "String User login, `none` for Issues with no assigned User. `*` for Issues with any assigned User."


### PR DESCRIPTION
http://developer.github.com/v3/issues/

By adding filters for `milestone` and `assignee` you limit the capability of the client. Requiring `milestone` means I must choose between `Issues with any Milestone` _OR_ `Issues with no Milestone`. If you leave out `milestone` you get `Issues with any Milestone` _AND_ `Issues with no Milestone`.
