### PR TITLE
Update the Oauth dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "devDependencies": {
         "asyncjs": "~0.0.4",
-        "oauth": "~0.8.0"
+        "oauth": "0.9.7"
     },
     "main" : ".",
     "scripts": {


### PR DESCRIPTION
When running the test/oauth.js with the current version `~0.8.0` listed in the `package.json`, 400 errors are thrown.

I updated the oauth library to `0.9.7` and it runs correctly.

Also, I noticed that `test\all.js` does not appear to be in the repository?

Thanks!
