### PR TITLE
Add the sort and direction options to repos.getAll and repos.getFromUser

### DIFF
--- a/api/v3.0.0/repos.js
+++ b/api/v3.0.0/repos.js
@@ -27,6 +27,8 @@ var repos = module.exports = {
      *  ##### Params on the `msg` object:
      * 
      *  - type (String): Optional. Possible values: `all`, `owner`, `public`, `private`, `member`. Default: `all`. Validation rule: ` ^(all|owner|public|private|member)$ `.
+     *  - sort (String): Optional. Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`. Validation rule: ` ^(created|updated|pushed|full_name)$ `.
+     *  - direction (String): Optional. Validation rule: ` ^(asc|desc)$ `.
      *  - page (Number): Optional. Page number of the results to fetch. Validation rule: ` ^[0-9]+$ `.
      *  - per_page (Number): Optional. A custom page size up to 100. Default is 30. Validation rule: ` ^[0-9]+$ `.
      **/
@@ -69,6 +71,8 @@ var repos = module.exports = {
      * 
      *  - user (String): Required. 
      *  - type (String): Optional. Possible values: `all`, `owner`, `member`. Default: `public`. Validation rule: ` ^(all|owner|member)$ `.
+     *  - sort (String): Optional. Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`. Validation rule: ` ^(created|updated|pushed|full_name)$ `.
+     *  - direction (String): Optional. Validation rule: ` ^(asc|desc)$ `.
      *  - page (Number): Optional. Page number of the results to fetch. Validation rule: ` ^[0-9]+$ `.
      *  - per_page (Number): Optional. A custom page size up to 100. Default is 30. Validation rule: ` ^[0-9]+$ `.
      **/

--- a/api/v3.0.0/reposTest.js
+++ b/api/v3.0.0/reposTest.js
@@ -33,6 +33,8 @@ var test = module.exports = {
             {
                 type: "String",
                 page: "Number",
+                sort: "String",
+                direction: "String",
                 per_page: "Number"
             },
             function(err, res) {
@@ -53,6 +55,8 @@ var test = module.exports = {
             {
                 user: "String",
                 type: "String",
+                sort: "String",
+                direction: "String",
                 page: "Number",
                 per_page: "Number"
             },

--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -1591,6 +1591,14 @@
                     "invalidmsg": "Possible values: `all`, `owner`, `public`, `private`, `member`. Default: `all`.",
                     "description": "Possible values: `all`, `owner`, `public`, `private`, `member`. Default: `all`."
                 },
+                "sort": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "^(created|updated|pushed|full_name)$",
+                    "invalidmsg": "Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`.",
+                    "description": "Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`."
+                },
+                "$direction": null,
                 "$page": null,
                 "$per_page": null
             }
@@ -1608,6 +1616,14 @@
                     "invalidmsg": "Possible values: `all`, `owner`, `member`. Default: `public`.",
                     "description": "Possible values: `all`, `owner`, `member`. Default: `public`."
                 },
+                "sort": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "^(created|updated|pushed|full_name)$",
+                    "invalidmsg": "Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`.",
+                    "description": "Possible values: `created`, `updated`, `pushed`, `full_name`. Default: `full_name`."
+                },
+                "$direction": null,
                 "$page": null,
                 "$per_page": null
             }


### PR DESCRIPTION
This exposes the sort and direction functionality in `repos.getAll` and `repos.getFromUser`.

I'd be happy to update/fix anything I missed.
