### PR TITLE
Make boolean flags work in the v3 API

### DIFF
--- a/index.js
+++ b/index.js
@@ -527,8 +527,11 @@ var Client = module.exports = function(config) {
         });
 
         // write data to request body
-        if (hasBody && query.length)
+        if (hasBody && query.length) {
+            if (self.debug)
+                console.log("REQUEST BODY: " + query + "\n");
             req.write(query + "\n");
+        }
         req.end();
     };
 }).call(Client.prototype);

--- a/index.js
+++ b/index.js
@@ -387,7 +387,7 @@ var Client = module.exports = function(config) {
         var url = def.url;
         Object.keys(def.params).forEach(function(paramName) {
             paramName = paramName.replace(/^[$]+/, "");
-            if (!msg[paramName])
+            if (!(paramName in msg))
                 return;
 
             var isUrlParam = url.indexOf(":" + paramName) !== -1;


### PR DESCRIPTION
The original code of [`getQueryAndUrl(msg, def, format)`](https://github.com/ajaxorg/node-github/blob/master/index.js#L390) is failing if a boolean flag has a falsey value:

``` js
if (!msg[paramName])
```

For example, if I use `client.repos.update` to set `private` to `false` it wouldn't be included in the request body. The new code however allows falsey values:

``` js
if (!(paramName in msg))
```

Boom!

I also added more debugging goodness, but YMMV.
