### PR TITLE
Create Commit comments params fix

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -1879,9 +1879,27 @@
                 "$sha": null,
                 "$body": null,
                 "$commit_id": null,
-                "$line": null,
-                "$path": null,
-                "$position": null
+                "path": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "Optional string - Relative path of the file to comment on."
+                },
+                "position": {
+                    "type": "Number",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "Optional number - Line index in the diff to comment on."
+                },
+                "line": {
+                    "type": "Number",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "Optional number - Line number in the file to comment on. Defaults to 1."
+                }
             }
         },
 


### PR DESCRIPTION
Path, line and position are only optional.
Commit comment without these params then ends under the whole list of commit diffs.
