### PR TITLE
Enable usage of "state" property for issues.repoIssues and issues.edit methods.

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -683,7 +683,13 @@
                     "invalidmsg": "",
                     "description": ""
                 },
-                "$state": null,
+                "state": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "^(open|closed)$",
+                    "invalidmsg": "open, closed, default: open",
+                    "description": "open or closed"
+                },
                 "assignee": {
                     "type": "String",
                     "required": false,
@@ -814,6 +820,13 @@
                     "validation": "",
                     "invalidmsg": "",
                     "description": "Optional array of strings - Labels to associate with this issue."
+                },
+                "state": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "^(open|closed)$",
+                    "invalidmsg": "open, closed, default: open",
+                    "description": "open or closed"
                 }
             }
         },


### PR DESCRIPTION
Updated the routes.json file to enable this.  The "state" property is supported for those methods by the Github API.
