### PR TITLE
Fixes team_id validation on repo createFromOrg

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -1749,7 +1749,7 @@
                 "team_id": {
                     "type": "Number",
                     "required": false,
-                    "validation": "^[0-9]$",
+                    "validation": "^[0-9]*$",
                     "invalidmsg": "",
                     "description": "Optional number - The id of the team that will be granted access to this repository. This is only valid when creating a repo in an organization."
                 }

--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -1749,7 +1749,7 @@
                 "team_id": {
                     "type": "Number",
                     "required": false,
-                    "validation": "^[0-9]*$",
+                    "validation": "^[0-9]+$",
                     "invalidmsg": "",
                     "description": "Optional number - The id of the team that will be granted access to this repository. This is only valid when creating a repo in an organization."
                 }


### PR DESCRIPTION
team_id can be any number, not only a single digit.
