### PR TITLE
Implements repos.delete

### DIFF
--- a/api/v3.0.0/repos.js
+++ b/api/v3.0.0/repos.js
@@ -332,6 +332,46 @@ var repos = module.exports = {
     };
 
     /** section: github
+     *  repos#delete(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     * 
+     *  ##### Params on the `msg` object:
+     * 
+     *  - user (String): Required. 
+     *  - repo (String): Required. 
+     **/
+    this.delete = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data && JSON.parse(res.data);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+            
+            if (!ret)
+                ret = {};
+            if (!ret.meta)
+                ret.meta = {};
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "link"].forEach(function(header) {
+                if (res.headers[header])
+                    ret.meta[header] = res.headers[header];
+            });
+            
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+    /** section: github
      *  repos#merge(msg, callback) -> null
      *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
      *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.

--- a/api/v3.0.0/reposTest.js
+++ b/api/v3.0.0/reposTest.js
@@ -156,6 +156,20 @@ describe("[repos]", function() {
         );
     });
 
+    it("should successfully execute DELETE /repos/:user/:repo (delete)",  function(next) {
+        client.repos.delete(
+            {
+                user: "String",
+                repo: "String"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
     it("should successfully execute POST /repos/:user/:repo/merges (merge)",  function(next) {
         client.repos.merge(
             {

--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -1781,6 +1781,15 @@
             }
         },
 
+        "delete": {
+            "url": "/repos/:user/:repo",
+            "method": "DELETE",
+            "params": {
+                "$user": null,
+                "$repo": null
+            }
+        },
+
         "merge": {
             "url": "/repos/:user/:repo/merges",
             "method": "POST",


### PR DESCRIPTION
See http://developer.github.com/v3/repos/#delete-a-repository

On a side note, running `node generate.js --version 3.0.0` on master does not cleanly generate the code and tests on master. Is this a known issue? I'm getting a number of subtle differences, which I edited out of this patch.
