### PR TITLE
issues/edit api's title and labels parameters are not required

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -789,7 +789,7 @@
                 "$number": null,
                 "title": {
                     "type": "String",
-                    "required": true,
+                    "required": false,
                     "validation": "",
                     "invalidmsg": "",
                     "description": ""
@@ -817,7 +817,7 @@
                 },
                 "labels": {
                     "type": "Json",
-                    "required": true,
+                    "required": false,
                     "validation": "",
                     "invalidmsg": "",
                     "description": "Optional array of strings - Labels to associate with this issue."


### PR DESCRIPTION
On documentation, issues edit api's **title** and **labels** parameter is optional
http://developer.github.com/v3/issues/#edit-an-issue

When I tried to execute this api only **body** parameter(without **title** and **labels**), got success result
