### PR TITLE
Fix create-reference

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -504,7 +504,7 @@
         },
 
         "create-reference": {
-            "url": "/repos/:user/:repo/git/refs",
+            "url": "/repos/:user/:repo/git/refs/:ref",
             "method": "POST",
             "params": {
                 "$user": null,


### PR DESCRIPTION
The `:ref` should be added to the end of the path, not placed in the body.
