### PR TITLE
Output of repos.getArchiveLink not useful

### DIFF
--- a/api/v3.0.0/repos.js
+++ b/api/v3.0.0/repos.js
@@ -1330,7 +1330,7 @@ var repos = module.exports = {
                 ret = {};
             if (!ret.meta)
                 ret.meta = {};
-            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-oauth-scopes", "link"].forEach(function(header) {
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-oauth-scopes", "link", 'location'].forEach(function(header) {
                 if (res.headers[header])
                     ret.meta[header] = res.headers[header];
             });

--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -2109,6 +2109,7 @@
             "params": {
                 "$user": null,
                 "$repo": null,
+                "$ref": null,
                 "archive_format": {
                     "type": "String",
                     "required": true,


### PR DESCRIPTION
When requesting a repo's archive link, the output of `getArchiveLink` is useless as it misses the location header that refers to the actual archive link: 

`{ 'x-ratelimit-limit': '5000', 'x-ratelimit-remaining': '4969' }`

Not sure what the correct output should be, but output-wise my commit aligns it with the API documentation for [get-archive-link](http://developer.github.com/v3/repos/contents/#get-archive-link); all its output is in the headers, but for usability sake we could add it in the main response.

Totally open for discussion here, though.
