### PR TITLE
Support Unicode data to be sent to GH as data

### DIFF
--- a/index.js
+++ b/index.js
@@ -626,10 +626,10 @@ var Client = module.exports = function(config) {
                 query = JSON.stringify(query);
             else
                 query = query.join("&");
-            headers["content-length"] = query.length;
+            headers["content-length"] = Buffer.byteLength(query, 'utf8');
             headers["content-type"] = format == "json"
-                ? "application/json"
-                : "application/x-www-form-urlencoded";
+                ? "application/json; charset=utf-8"
+                : "application/x-www-form-urlencoded; charset=utf-8";
         }
         if (this.auth) {
             var basic;


### PR DESCRIPTION
Hi Mike,

Looks like when you create a commit with the GH library (against GH API) with eg. `汉语` (Chinese) or another non-ascii chars `Testing «ταБЬℓσ»`, the Content-Length is wrongly counted (String.prototype.length = chars length, not Byte length).

And this fixes it.
