### PR TITLE
Add 'all' filter on Issues

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -651,7 +651,7 @@
                 "filter": {
                     "type": "String",
                     "required": false,
-                    "validation": "^(assigned|created|mentioned|subscribed)$",
+                    "validation": "^(all|assigned|created|mentioned|subscribed)$",
                     "invalidmsg": "",
                     "description": ""
                 },


### PR DESCRIPTION
According to [Github's API](http://developer.github.com/v3/issues/#list-issues), you can use an `all` filter to get all issues the authenticated user can see, regardless of participation or creation.
