### PR TITLE
Callback at timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -701,6 +701,15 @@ var Client = module.exports = function(config) {
             }
         });
 
+        req.on("timeout", function() {
+            if (self.debug)
+                console.log("problem with request: timed out");
+            if(!callbackCalled) {
+                callbackCalled = true;
+                callback(new error.HttpError("timeout", 504));
+            }
+        });
+
         // write data to request body
         if (hasBody && query.length) {
             if (self.debug)

--- a/index.js
+++ b/index.js
@@ -706,7 +706,7 @@ var Client = module.exports = function(config) {
                 console.log("problem with request: timed out");
             if (!callbackCalled) {
                 callbackCalled = true;
-                callback(new error.HttpError("timeout", 504));
+                callback(new error.GatewayTimeout());
             }
         });
 

--- a/index.js
+++ b/index.js
@@ -704,7 +704,7 @@ var Client = module.exports = function(config) {
         req.on("timeout", function() {
             if (self.debug)
                 console.log("problem with request: timed out");
-            if(!callbackCalled) {
+            if (!callbackCalled) {
                 callbackCalled = true;
                 callback(new error.HttpError("timeout", 504));
             }


### PR DESCRIPTION
In documentaion is written, that I can set up a timeout for the Github API call.

Unfortunately it is not triggering the given callback.

Reason for that the timeout according to node.js documentation.

> When an idle timeout is triggered the socket will receive a 'timeout' event but the connection will not be severed. The user must manually end() or destroy() the socket.

**Current behaviour:**
Timeout is not triggering callback.

**Wished behaviour:**
Timeout is triggering callback with time error und status code 504.
