### PR TITLE
Proper proxy handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -627,11 +627,14 @@ var Client = module.exports = function(config) {
                 port: port,
                 pathname: path
             });
-            
+
+            if (!/^(http|https):\/\//.test(proxyUrl))
+                proxyUrl = 'http://' + proxyUrl;
+
             var parsedUrl = Url.parse(proxyUrl);
-            host = parsedUrl.hostname;
-            port = parsedUrl.port;
             protocol = parsedUrl.protocol.replace(':', '');
+            host = parsedUrl.hostname;
+            port = parsedUrl.port || (protocol == "https" ? 443 : 80);
         }
         if (!hasBody && query.length)
             path += "?" + query.join("&");

--- a/index.js
+++ b/index.js
@@ -629,7 +629,7 @@ var Client = module.exports = function(config) {
             });
 
             if (!/^(http|https):\/\//.test(proxyUrl))
-                proxyUrl = 'http://' + proxyUrl;
+                proxyUrl = 'https://' + proxyUrl;
 
             var parsedUrl = Url.parse(proxyUrl);
             protocol = parsedUrl.protocol.replace(':', '');

--- a/index.js
+++ b/index.js
@@ -623,7 +623,8 @@ var Client = module.exports = function(config) {
         if (proxyUrl) {
             path = Url.format({
                 protocol: protocol,
-                host: host,
+                hostname: host,
+                port: port,
                 pathname: path
             });
             

--- a/index.js
+++ b/index.js
@@ -629,10 +629,10 @@ var Client = module.exports = function(config) {
             });
 
             if (!/^(http|https):\/\//.test(proxyUrl))
-                proxyUrl = 'https://' + proxyUrl;
+                proxyUrl = "https://" + proxyUrl;
 
             var parsedUrl = Url.parse(proxyUrl);
-            protocol = parsedUrl.protocol.replace(':', '');
+            protocol = parsedUrl.protocol.replace(":", "");
             host = parsedUrl.hostname;
             port = parsedUrl.port || (protocol == "https" ? 443 : 80);
         }


### PR DESCRIPTION
I am currently trying to access github API through a http proxy, so I'd like to propose a little patch to improve proxy handling.

What it changes :
1) the proxy setting is the complete address ( ex: config.proxy = "http://someproxy:8080" )
2) if the protocol is omitted, it uses HTTPS
3) If the port is omitted, it uses 443 for https or 80 for http
3) if no proxy was given, the HTTPS_PROXY environment variable is used, or HTTP_PROXY if it's not set
4) the proxy in the config overrides environment variables, so one can give NULL to use none
5) when using a proxy, the request path is the full targetted url (before the host was missing, so the proxy had no clue where to send the request)

That's all folks! I only tested it in my case, so any feedback would be appreciated :)
