### PR TITLE
Allow `Accept` request header

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -23,7 +23,8 @@
             "If-Modified-Since",
             "If-None-Match",
             "Cookie",
-            "User-Agent"
+            "User-Agent",
+            "Accept"
         ],
         "params": {
             "files": {


### PR DESCRIPTION
GitHub uses `Accept` to specify different response versions/formats.
See: https://developer.github.com/v3/media/
