### PR TITLE
migrate to the new search api for issues

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -2991,25 +2991,31 @@
     },
     "search": {
         "issues": {
-            "url": "/legacy/issues/search/:user/:repo/:state/:keyword",
+            "url": "/search/issues",
             "method": "GET",
             "params": {
-                "$user": null,
-                "$repo": null,
-                "state": {
-                    "type": "String",
-                    "required": true,
-                    "validation": "^(open|closed)$",
-                    "invalidmsg": "open, closed, default: open",
-                    "description": "open or closed"
-                },
-                "keyword": {
+                "q": {
                     "type": "String",
                     "required": true,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "Search term"
+                    "description": "Search Term"
+                },
+                "sort": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "^(comments|created|updated)$",
+                    "invalidmsg": "comments, created, or updated",
+                    "description": "comments, created, or updated"
+                },
+                "order": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "^(asc|desc)$",
+                    "invalidmsg": "The sort order if sort parameter is provided. One of asc or desc. Default: desc",
+                    "description": "asc or desc"
                 }
+
             }
         },
 

--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -3015,55 +3015,61 @@
                     "invalidmsg": "The sort order if sort parameter is provided. One of asc or desc. Default: desc",
                     "description": "asc or desc"
                 }
-
             }
         },
 
         "repos": {
-            "url": "/legacy/repos/search/:keyword",
+            "url": "/search/repositories",
             "method": "GET",
             "params": {
-                "keyword": {
+                "q": {
                     "type": "String",
                     "required": true,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "Search term"
+                    "description": "Search Term"
                 },
-                "language": {
+                "sort": {
                     "type": "String",
                     "required": false,
-                    "validation": "",
-                    "invalidmsg": "",
-                    "description": "Filter results by language, see https://github.com/languages"
+                    "validation": "^(stars|forks|updated)$",
+                    "invalidmsg": "One of stars, forks, or updated. Default: results are sorted by best match.",
+                    "description": "stars, forks, or updated"
                 },
-                "start_page": {
-                    "type": "Number",
+                "order": {
+                    "type": "String",
                     "required": false,
-                    "validation": "^[0-9]+$",
-                    "invalidmsg": "",
-                    "description": "Page number to fetch"
+                    "validation": "^(asc|desc)$",
+                    "invalidmsg": "The sort order if sort parameter is provided. One of asc or desc. Default: desc",
+                    "description": "asc or desc"
                 }
             }
         },
 
         "users": {
-            "url": "/legacy/user/search/:keyword",
+            "url": "/search/users",
             "method": "GET",
             "params": {
-                "keyword": {
+                "q": {
                     "type": "String",
                     "required": true,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "Keyword search parameters"
+                    "description": "Search Term"
                 },
-                "start_page": {
-                    "type": "Number",
+                "sort": {
+                    "type": "String",
                     "required": false,
-                    "validation": "^[0-9]+$",
-                    "invalidmsg": "",
-                    "description": "Page number to fetch"
+                    "validation": "^(followers|repositories|joined)$",
+                    "invalidmsg": "Can be followers, repositories, or joined. Default: results are sorted by best match.",
+                    "description": "followers, repositories, or joined"
+                },
+                "order": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "^(asc|desc)$",
+                    "invalidmsg": "The sort order if sort parameter is provided. One of asc or desc. Default: desc",
+                    "description": "asc or desc"
                 }
             }
         },


### PR DESCRIPTION
Most of the logic is now in the q parameter. special options could be added to handle the various other options q takes in such as repo, user, etc or it can be left up to the end user. My thought was leave it to end user and just changed the routes to support the new api. 

Makes progress on Issue #110
