### PR TITLE
Fix search

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -3096,7 +3096,8 @@
                     "required": true,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "Search Term"
+                    "description": "Search Term",
+                    "encode": false
                 },
                 "sort": {
                     "type": "String",
@@ -3118,7 +3119,8 @@
                     "required": true,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "Search Term"
+                    "description": "Search Term",
+                    "encode": false
                 },
                 "sort": {
                     "type": "String",
@@ -3140,7 +3142,8 @@
                     "required": true,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "Search Term"
+                    "description": "Search Term",
+                    "encode": false
                 },
                 "sort": {
                     "type": "String",

--- a/api/v3.0.0/searchTest.js
+++ b/api/v3.0.0/searchTest.js
@@ -29,17 +29,13 @@ describe("[search]", function() {
     it("should successfully execute GET /legacy/issues/search/:user/:repo/:state/:keyword (issues)",  function(next) {
         client.search.issues(
             {
-                user: "mikedeboertest",
-                repo: "node_chat",
-                state: "open",
-                keyword: "macaroni"
+                q: ['macaroni', 'repo:mikedeboertest/node_chat', 'state:open'].join('+')
             },
             function(err, res) {
                 Assert.equal(err, null);
-                Assert.equal(res.issues.length, 1);
-                var issue = res.issues[0];
+                Assert.equal(res.items.length, 1);
+                var issue = res.items[0];
                 Assert.equal(issue.title, "My First Issue");
-                Assert.equal(issue.position, 1);
                 Assert.equal(issue.state, "open");
 
                 next();
@@ -50,13 +46,12 @@ describe("[search]", function() {
     it("should successfully execute GET /legacy/repos/search/:keyword (repos)",  function(next) {
         client.search.repos(
             {
-                keyword: "pasta",
-                language: "JavaScript"
+                q: ['pasta', 'language:JavaScript'].join('+')
             },
             function(err, res) {
                 Assert.equal(err, null);
-                Assert.ok(res.repositories.length > 0);
-                Assert.equal(res.repositories[0].language, "JavaScript");
+                Assert.ok(res.items.length > 0);
+                Assert.equal(res.items[0].language, "JavaScript");
 
                 next();
             }
@@ -66,14 +61,13 @@ describe("[search]", function() {
     it("should successfully execute GET /legacy/user/search/:keyword (users)",  function(next) {
         client.search.users(
             {
-                keyword: "mikedeboer"
+                q: "mikedeboer"
             },
             function(err, res) {
                 Assert.equal(err, null);
-                Assert.equal(res.users.length, 2);
-                var user = res.users[0];
-                Assert.equal(user.name, "Mike de Boer");
-                Assert.ok(user.username.indexOf("mikedeboer") === 0);
+                Assert.equal(res.items.length, 2);
+                var user = res.items[0];
+                Assert.equal(user.login, "mikedeboer");
 
                 next();
             }

--- a/index.js
+++ b/index.js
@@ -592,7 +592,7 @@ var Client = module.exports = function(config) {
                 }
             }
             else
-                val = valFormat == "json" ? msg[paramName] : encodeURIComponent(msg[paramName]);
+                val = valFormat == "json" || def.params[paramName].encode === false ? msg[paramName] : encodeURIComponent(msg[paramName]);
 
             if (isUrlParam) {
                 url = url.replace(":" + paramName, val);

--- a/index.js
+++ b/index.js
@@ -580,6 +580,7 @@ var Client = module.exports = function(config) {
 
             var isUrlParam = url.indexOf(":" + paramName) !== -1;
             var valFormat = isUrlParam || format != "json" ? "query" : format;
+            var skipEncoding = def.params[paramName] && def.params[paramName].encode === false;
             var val;
             if (valFormat != "json" && typeof msg[paramName] == "object") {
                 try {
@@ -592,7 +593,7 @@ var Client = module.exports = function(config) {
                 }
             }
             else
-                val = valFormat == "json" || def.params[paramName].encode === false ? msg[paramName] : encodeURIComponent(msg[paramName]);
+                val = valFormat == "json" || skipEncoding ? msg[paramName] : encodeURIComponent(msg[paramName]);
 
             if (isUrlParam) {
                 url = url.replace(":" + paramName, val);
@@ -634,7 +635,7 @@ var Client = module.exports = function(config) {
         var protocol = this.config.protocol || this.constants.protocol || "http";
         var host = this.config.host || this.constants.host;
         var port = this.config.port || this.constants.port || (protocol == "https" ? 443 : 80);
-        
+
         var proxyUrl;
         if (this.config.proxy !== undefined) {
             proxyUrl = this.config.proxy;
@@ -736,8 +737,8 @@ var Client = module.exports = function(config) {
             });
             res.on("error", function(err) {
                 if (!callbackCalled) {
-                   callbackCalled = true;   
-                   callback(err); 
+                   callbackCalled = true;
+                   callback(err);
                 }
             });
             res.on("end", function() {


### PR DESCRIPTION
The new search parameter `q` was being encoded, which breaks when you specify additional search parameters.  This should fix that.  I also updated the search tests to be working.
