### PR TITLE
Add default request accept header, configurable via config.requestMedia

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -7,7 +7,8 @@
             "host": "api.github.com",
             "port": 443,
             "dateFormat": "YYYY-MM-DDTHH:MM:SSZ",
-            "requestFormat": "json"
+            "requestFormat": "json",
+            "requestMedia": "application/vnd.github.beta+json"
         },
         "response-headers": [
             "X-RateLimit-Limit",

--- a/index.js
+++ b/index.js
@@ -711,6 +711,9 @@ var Client = module.exports = function(config) {
         if (!headers["user-agent"])
             headers["user-agent"] = "NodeJS HTTP Client";
 
+        if (!headers["accept"])
+            headers["accept"] = this.config.requestMedia || this.constants.requestMedia;
+
         var options = {
             host: host,
             port: port,


### PR DESCRIPTION
Because [GitHub API server changes behavior](http://developer.github.com/changes/2014-01-07-upcoming-change-to-default-media-type/) and returns [slightly different content](http://developer.github.com/v3/versions/#differences-from-beta-version), it would be probably _best_ to have "beta mediaType" as default.

Can be configured per one call (`headers`), or with githubApi instance through `config.requestMedia`.

> Starting April 15, 2014, the beta version will no longer be the default version. However, we expect to continue supporting the beta version for a while.
