### PR TITLE
fix fork to organization

### DIFF
--- a/api/v3.0.0/repos.js
+++ b/api/v3.0.0/repos.js
@@ -1740,7 +1740,7 @@ var repos = module.exports = {
      *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
      *  - user (String): Required. 
      *  - repo (String): Required. 
-     *  - org (String): Optional. Optional String - Organization login. The repository will be forked into this organization. 
+     *  - organization (String): Optional. Optional String - Organization login. The repository will be forked into this organization. 
      **/
     this.fork = function(msg, block, callback) {
         var self = this;

--- a/api/v3.0.0/reposTest.js
+++ b/api/v3.0.0/reposTest.js
@@ -686,7 +686,7 @@ describe("[repos]", function() {
             {
                 user: "String",
                 repo: "String",
-                org: "String"
+                organization: "String"
             },
             function(err, res) {
                 Assert.equal(err, null);

--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -2470,7 +2470,7 @@
             "params": {
                 "$user": null,
                 "$repo": null,
-                "org": {
+                "organization": {
                     "type": "String",
                     "required": false,
                     "validation": "",
@@ -2545,7 +2545,7 @@
             }
         },
 
-        "get-starred": { 
+        "get-starred": {
             "url": "/user/starred",
             "method": "GET",
             "params": {


### PR DESCRIPTION
While working on our chat bot I came across a bug in forking to an organization - the body should be `{"organization":"orgName"}` not `{"org":"orgName"}` as it was before. http://developer.github.com/v3/repos/forks/#create-a-fork. It probably wasn't caught by tests because Github would happily just fork to the user and return a 202.

Happy to complete any additional work to get this fix in. 

Cheers
