### PR TITLE
Sort param on Pull Request -> getAll method

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -1557,6 +1557,8 @@
                     "validation": "^(created|updated|popularity|long-running)$",
                     "invalidmsg": "Possible values are: `created`, `updated`, `popularity`, `long-running`, Default: `created`",
                     "description": "Possible values are: `created`, `updated`, `popularity`, `long-running`, Default: `created`"
+                },
+                "$direction": null
             }
         },
 

--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -1550,7 +1550,13 @@
                 "$repo": null,
                 "$state": null,
                 "$page": null,
-                "$per_page": null
+                "$per_page": null,
+                "sort": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "^(created|updated|popularity|long-running)$",
+                    "invalidmsg": "Possible values are: `created`, `updated`, `popularity`, `long-running`, Default: `created`",
+                    "description": "Possible values are: `created`, `updated`, `popularity`, `long-running`, Default: `created`"
             }
         },
 


### PR DESCRIPTION
Hey @mikedeboer, it seems that `node-github` doesn't support [`sort`](http://developer.github.com/v3/pulls/#list-pull-requests) parameter on `Pull Request -> getAll` method. I need to use this parameter on [node-gh](https://github.com/node-gh/gh).

Do you think it's a good idea to add it on node-github API?
I can submit a patch if you point me on the correct direction.

Thanks.
