### PR TITLE
Add ability to specify commit author for client.repos.getCommits()

### DIFF
--- a/api/v3.0.0/reposTest.js
+++ b/api/v3.0.0/reposTest.js
@@ -354,7 +354,8 @@ describe("[repos]", function() {
                 sha: "String",
                 path: "String",
                 page: "Number",
-                per_page: "Number"
+                per_page: "Number",
+                author: "String"
             },
             function(err, res) {
                 Assert.equal(err, null);

--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -2063,6 +2063,13 @@
                     "invalidmsg": "",
                     "description": "Optional string - Only commits containing this file path will be returned."
                 },
+                "author": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "Optional string - GitHub login or email address by which to filter by commit author."
+                },
                 "$page": null,
                 "$per_page": null,
                 "$since": null


### PR DESCRIPTION
The [v3 API](https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository) allows you to specify an author when using a repo's commits endpoint, so that you can filter down to commits made by a specific person. This PR updates the allowable params for that route to let you pass it through as an optional param.
