### PR TITLE
Update routes.json to allow state = 'all'

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -779,9 +779,9 @@
                 "state": {
                     "type": "String",
                     "required": false,
-                    "validation": "^(open|closed)$",
-                    "invalidmsg": "open, closed, default: open",
-                    "description": "open or closed"
+                    "validation": "^(open|closed|all)$",
+                    "invalidmsg": "open, closed, all, default: open",
+                    "description": "open, closed, or all"
                 },
                 "assignee": {
                     "type": "String",


### PR DESCRIPTION
Update routes.json to allow state = 'all' for fetching issues from a repo.

Mention in the API docs: https://developer.github.com/v3/issues/#parameters
