### PR TITLE
Support pagination for issue labels API

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -14,7 +14,7 @@
             "X-RateLimit-Limit",
             "X-RateLimit-Remaining",
             "X-Oauth-Scopes",
-            "Link",l
+            "Link",
             "Location",
             "Last-Modified",
             "Etag",

--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -14,7 +14,7 @@
             "X-RateLimit-Limit",
             "X-RateLimit-Remaining",
             "X-Oauth-Scopes",
-            "Link",
+            "Link",l
             "Location",
             "Last-Modified",
             "Etag",
@@ -1048,7 +1048,9 @@
             "method": "GET",
             "params": {
                 "$user": null,
-                "$repo": null
+                "$repo": null,
+                "$page": null,
+                "$per_page": null
             }
         },
 


### PR DESCRIPTION
The Github v3 API supports pagination when retrieving issue labels, through the standard `page`and `per_page` parameters [1]. This is true even though the parameters are not explicitly mentioned in the - rather brief - documentation of the issue labels API call [2]

[1] https://developer.github.com/guides/traversing-with-pagination/
[2] https://developer.github.com/v3/issues/labels/
