### PR TITLE
issues.get should support filter state=all

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -741,7 +741,13 @@
                     "invalidmsg": "",
                     "description": ""
                 },
-                "$state": null,
+                "state": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "^(open|closed|all)$",
+                    "invalidmsg": "open, closed, all, default: open",
+                    "description": "open, closed, or all"
+                },
                 "labels": {
                     "type": "String",
                     "required": false,


### PR DESCRIPTION
Github supports parameter to retrieve issues with in all states also for the `/issues` call. Adding configuration in routes.json to allow it to be used.

A similar customization has been made for the `/repos/:user/:repo/issues` call but was omitted here.

Many thanks for the very useful package!
