### PR TITLE
Adds the releases api

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ github.authorization.create({
 * Search: 100%
 * Markdown: 100%
 * Rate Limit: 100%
+* Releases: 90%
 
 ## Running the Tests
 

--- a/api/v3.0.0/index.js
+++ b/api/v3.0.0/index.js
@@ -33,7 +33,7 @@ var proto = {
     }
 };
 
-["gists", "gitdata", "issues", "authorization", "orgs", "statuses", "pullRequests", "repos", "user", "events", "search", "markdown", "misc"].forEach(function(api) {
+["gists", "gitdata", "issues", "authorization", "orgs", "statuses", "pullRequests", "repos", "user", "events", "releases", "search", "markdown", "misc"].forEach(function(api) {
     Util.extend(proto, require("./" + api));
 });
 

--- a/api/v3.0.0/releases.js
+++ b/api/v3.0.0/releases.js
@@ -1,0 +1,414 @@
+/**
+ *  mixin releases
+ *
+ *  Copyright 2012 Cloud9 IDE, Inc.
+ *
+ *  This product includes software developed by
+ *  Cloud9 IDE, Inc (http://c9.io).
+ *
+ *  Author: Mike de Boer <info@mikedeboer.nl>
+ **/
+
+"use strict";
+
+var error = require("./../../error");
+var Util = require("./../../util");
+
+var releases = module.exports = {
+    releases: {}
+};
+
+(function() {
+    /** section: github
+     *  releases#listReleases(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     *
+     *  ##### Params on the `msg` object:
+     *
+     *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
+     *  - owner (String): Required. 
+     *  - repo (String): Required. 
+     *  - page (Number): Optional. Page number of the results to fetch. Validation rule: ` ^[0-9]+$ `.
+     *  - per_page (Number): Optional. A custom page size up to 100. Default is 30. Validation rule: ` ^[0-9]+$ `.
+     **/
+    this.listReleases = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data && JSON.parse(res.data);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+
+            if (!ret)
+                ret = {};
+            if (!ret.meta)
+                ret.meta = {};
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
+                if (res.headers[header])
+                    ret.meta[header] = res.headers[header];
+            });
+
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+    /** section: github
+     *  releases#getRelease(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     *
+     *  ##### Params on the `msg` object:
+     *
+     *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
+     *  - owner (String): Required. 
+     *  - id (Number): Required. 
+     *  - repo (String): Required. 
+     **/
+    this.getRelease = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data && JSON.parse(res.data);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+
+            if (!ret)
+                ret = {};
+            if (!ret.meta)
+                ret.meta = {};
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
+                if (res.headers[header])
+                    ret.meta[header] = res.headers[header];
+            });
+
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+    /** section: github
+     *  releases#createRelease(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     *
+     *  ##### Params on the `msg` object:
+     *
+     *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
+     *  - owner (String): Required. 
+     *  - repo (String): Required. 
+     *  - tag_name (String): Required. String of the tag
+     *  - target_commitish (String): Optional. Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually master).
+     *  - name (String): Optional. 
+     *  - body (String): Optional. 
+     *  - draft (Boolean): Optional. true to create a draft (unpublished) release, false to create a published one. Default: false
+     *  - prerelease (Boolean): Optional. true to identify the release as a prerelease. false to identify the release as a full release. Default: false
+     **/
+    this.createRelease = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data && JSON.parse(res.data);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+
+            if (!ret)
+                ret = {};
+            if (!ret.meta)
+                ret.meta = {};
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
+                if (res.headers[header])
+                    ret.meta[header] = res.headers[header];
+            });
+
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+    /** section: github
+     *  releases#editRelease(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     *
+     *  ##### Params on the `msg` object:
+     *
+     *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
+     *  - owner (String): Required. 
+     *  - id (Number): Required. 
+     *  - repo (String): Required. 
+     *  - tag_name (String): Required. String of the tag
+     *  - target_commitish (String): Optional. Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository�s default branch (usually master).
+     *  - name (String): Optional. 
+     *  - body (String): Optional. 
+     *  - draft (Boolean): Optional. true to create a draft (unpublished) release, false to create a published one. Default: false
+     *  - prerelease (Boolean): Optional. true to identify the release as a prerelease. false to identify the release as a full release. Default: false
+     **/
+    this.editRelease = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data && JSON.parse(res.data);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+
+            if (!ret)
+                ret = {};
+            if (!ret.meta)
+                ret.meta = {};
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
+                if (res.headers[header])
+                    ret.meta[header] = res.headers[header];
+            });
+
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+    /** section: github
+     *  releases#deleteRelease(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     *
+     *  ##### Params on the `msg` object:
+     *
+     *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
+     *  - owner (String): Required. 
+     *  - id (Number): Required. 
+     *  - repo (String): Required. 
+     **/
+    this.deleteRelease = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data && JSON.parse(res.data);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+
+            if (!ret)
+                ret = {};
+            if (!ret.meta)
+                ret.meta = {};
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
+                if (res.headers[header])
+                    ret.meta[header] = res.headers[header];
+            });
+
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+    /** section: github
+     *  releases#listAssets(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     *
+     *  ##### Params on the `msg` object:
+     *
+     *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
+     *  - owner (String): Required. 
+     *  - id (Number): Required. 
+     *  - repo (String): Required. 
+     **/
+    this.listAssets = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data && JSON.parse(res.data);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+
+            if (!ret)
+                ret = {};
+            if (!ret.meta)
+                ret.meta = {};
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
+                if (res.headers[header])
+                    ret.meta[header] = res.headers[header];
+            });
+
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+    /** section: github
+     *  releases#getAsset(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     *
+     *  ##### Params on the `msg` object:
+     *
+     *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
+     *  - owner (String): Required. 
+     *  - id (Number): Required. 
+     *  - repo (String): Required. 
+     **/
+    this.getAsset = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data && JSON.parse(res.data);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+
+            if (!ret)
+                ret = {};
+            if (!ret.meta)
+                ret.meta = {};
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
+                if (res.headers[header])
+                    ret.meta[header] = res.headers[header];
+            });
+
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+    /** section: github
+     *  releases#editAsset(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     *
+     *  ##### Params on the `msg` object:
+     *
+     *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
+     *  - owner (String): Required. 
+     *  - id (Number): Required. 
+     *  - repo (String): Required. 
+     *  - name (String): Required. 
+     *  - label (String): Optional. An alternate short description of the asset. Used in place of the filename.
+     **/
+    this.editAsset = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data && JSON.parse(res.data);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+
+            if (!ret)
+                ret = {};
+            if (!ret.meta)
+                ret.meta = {};
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
+                if (res.headers[header])
+                    ret.meta[header] = res.headers[header];
+            });
+
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+    /** section: github
+     *  releases#deleteAsset(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     *
+     *  ##### Params on the `msg` object:
+     *
+     *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
+     *  - owner (String): Required. 
+     *  - id (Number): Required. 
+     *  - repo (String): Required. 
+     **/
+    this.deleteAsset = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data && JSON.parse(res.data);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+
+            if (!ret)
+                ret = {};
+            if (!ret.meta)
+                ret.meta = {};
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
+                if (res.headers[header])
+                    ret.meta[header] = res.headers[header];
+            });
+
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+}).call(releases.releases);

--- a/api/v3.0.0/releasesTest.js
+++ b/api/v3.0.0/releasesTest.js
@@ -1,0 +1,232 @@
+ /*
+ * Copyright 2012 Cloud9 IDE, Inc.
+ *
+ * This product includes software developed by
+ * Cloud9 IDE, Inc (http://c9.io).
+ *
+ * Author: Mike de Boer <info@mikedeboer.nl>
+ */
+
+"use strict";
+
+var Assert = require("assert");
+var Client = require("./../../index");
+
+describe("[releases]", function() {
+    var client;
+    var token = "c286e38330e15246a640c2cf32a45ea45d93b2ba";
+
+    var owner = "greggman";
+    var repo  = "test";
+    var haveWriteAccess = true;       // set to false if the authenticated person below does not have write access to the repo above
+    var releaseIdWithAsset = 393621;  // Some release id from the repo above that has at least 1 asset.
+
+    var releaseId;      // release id found when listing releases. Used for get release
+    var newReleaseId;   // release id created when creating release, used for edit and delete release
+    var assetId;        // asset id found when listing assets. Used for get asset
+    var newAssetId;     // asset id used when creating asset. Used for edit and delete asset
+
+    beforeEach(function() {
+        client = new Client({
+            version: "3.0.0"
+        });
+        client.authenticate({
+            type: "oauth",
+            token: token
+        });
+    });
+
+    it("should successfully execute GET /repos/:owner/:repo/releases (listReleases)",  function(next) {
+        client.releases.listReleases(
+            {
+              owner: owner,
+              repo: repo,
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                Assert.ok(res instanceof Array);
+                if (res instanceof Array && res.length > 0) {
+                  releaseId = res[0].id;
+                }
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute GET /repos/:owner/:repo/releases/:id (getRelease)",  function(next) {
+        if (!releaseId) {
+            next();
+            return;
+        }
+        client.releases.getRelease(
+            {
+                owner: owner,
+                id: releaseId,
+                repo: repo
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                Assert.equal(res.id, releaseId);
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute POST /repos/:owner/:repo/releases (createRelease)",  function(next) {
+        if (!haveWriteAccess) {
+          next();
+          return;
+        }
+        client.releases.createRelease(
+            {
+                owner: owner,
+                repo: repo,
+                tag_name: "node-github-tag",
+                target_commitish: "master",
+                name: "node-github-name",
+                body: "node-github-body",
+                draft: false,
+                prerelease: true,
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                Assert.equal(res.tag_name, "node-github-tag");
+                Assert.equal(res.target_commitish, "master");
+                Assert.equal(res.name, "node-github-name");
+                Assert.equal(res.body, "node-github-body");
+                Assert.equal(res.assets.length, 0);
+                Assert.ok(res.prerelease);
+                Assert.ok(!res.draft);
+                newReleaseId = res.id;
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute PATCH /repos/:owner/:repo/releases/:id (editRelease)",  function(next) {
+        if (!haveWriteAccess) {
+          next();
+          return;
+        }
+        client.releases.editRelease(
+            {
+                owner: owner,
+                id: newReleaseId,
+                repo: repo,
+                tag_name: "node-github-new-tag",
+                target_commitish: "master",
+                name: "node-github-new-name",
+                body: "node-github-new-body",
+                draft: true,
+                prerelease: true,
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                Assert.equal(res.id, newReleaseId);
+                Assert.equal(res.tag_name, "node-github-new-tag");
+                Assert.equal(res.target_commitish, "master");
+                Assert.equal(res.name, "node-github-new-name");
+                Assert.equal(res.body, "node-github-new-body");
+                Assert.equal(res.assets.length, 0);
+                Assert.ok(res.prerelease);
+                Assert.ok(res.draft);
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute DELETE /repos/:owner/:repo/releases/:id (deleteRelease)",  function(next) {
+        if (!haveWriteAccess) {
+          next();
+          return;
+        }
+        client.releases.deleteRelease(
+            {
+                owner: owner,
+                repo: repo,
+                id: newReleaseId,
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute GET /repos/:owner/:repo/releases/:id/assets (listAssets)",  function(next) {
+        client.releases.listAssets(
+            {
+                owner: owner,
+                id: releaseIdWithAsset,
+                repo: repo
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                Assert.ok(res instanceof Array);
+                if (res instanceof Array && res.length > 0) {
+                    assetId = res[0].id;
+                }
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute GET /repos/:owner/:repo/releases/assets/:id (getAsset)",  function(next) {
+        if (!assetId) {
+            next();
+            return;
+        }
+        client.releases.getAsset(
+            {
+                owner: owner,
+                id: assetId,
+                repo: repo
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                Assert.equal(res.id, assetId);
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute PATCH /repos/:owner/:repo/releases/assets/:id (editAsset)",  function(next) {
+        if (!newAssetId) {
+            next();
+            return;
+        }
+        client.releases.editAsset(
+            {
+                owner: owner,
+                id: "Number",
+                repo: repo,
+                name: "String",
+                label: "String"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute DELETE /repos/:owner/:repo/releases/assets/:id (deleteAsset)",  function(next) {
+        if (!newAssetId) {
+            next();
+            return;
+        }
+        client.releases.deleteAsset(
+            {
+                owner: owner,
+                id: "Number",
+                repo: repo
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+});

--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -3152,6 +3152,277 @@
             }
         }
     },
+
+    "releases": {
+        "list-releases": {
+            "url": "/repos/:owner/:repo/releases",
+            "method": "GET",
+            "params": {
+                "owner": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "$repo": null,
+                "$page": null,
+                "$per_page": null
+            }
+        },
+        "get-release": {
+            "url": "/repos/:owner/:repo/releases/:id",
+            "method": "GET",
+            "params": {
+                "owner": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "id": {
+                    "type": "Number",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "$repo": null
+            }
+        },
+        "create-release": {
+            "url": "/repos/:owner/:repo/releases",
+            "method": "POST",
+            "params": {
+                "owner": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "$repo": null,
+                "tag_name": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "String of the tag"
+                },
+                "target_commitish": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually master)."
+                },
+                "name": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "body": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "draft": {
+                    "type": "Boolean",
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "true to create a draft (unpublished) release, false to create a published one. Default: false"
+                },
+                "prerelease": {
+                    "type": "Boolean",
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "true to identify the release as a prerelease. false to identify the release as a full release. Default: false"
+                }
+            }
+        },
+        "edit-release": {
+            "url": "/repos/:owner/:repo/releases/:id",
+            "method": "PATCH",
+            "params": {
+                "owner": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "id": {
+                    "type": "Number",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "$repo": null,
+                "tag_name": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "String of the tag"
+                },
+                "target_commitish": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository’s default branch (usually master)."
+                },
+                "name": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "body": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "draft": {
+                    "type": "Boolean",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "true to create a draft (unpublished) release, false to create a published one. Default: false"
+                },
+                "prerelease": {
+                    "type": "Boolean",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "true to identify the release as a prerelease. false to identify the release as a full release. Default: false"
+                }
+            }
+        },
+        "delete-release": {
+            "url": "/repos/:owner/:repo/releases/:id",
+            "method": "DELETE",
+            "params": {
+                "owner": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "id": {
+                    "type": "Number",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "$repo": null
+            }
+        },
+        "list-assets": {
+            "url": "/repos/:owner/:repo/releases/:id/assets",
+            "method": "GET",
+            "params": {
+                "owner": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "id": {
+                    "type": "Number",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "$repo": null
+            }
+        },
+        "get-asset": {
+            "url": "/repos/:owner/:repo/releases/assets/:id",
+            "method": "GET",
+            "params": {
+                "owner": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "id": {
+                    "type": "Number",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "$repo": null
+            }
+        },
+        "edit-asset": {
+            "url": "/repos/:owner/:repo/releases/assets/:id",
+            "method": "PATCH",
+            "params": {
+                "owner": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "id": {
+                    "type": "Number",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "$repo": null,
+                "$name": null,
+                "label": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "An alternate short description of the asset. Used in place of the filename."
+                }
+            }
+        },
+        "delete-asset": {
+            "url": "/repos/:owner/:repo/releases/assets/:id",
+            "method": "DELETE",
+            "params": {
+                "owner": {
+                    "type": "String",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "id": {
+                    "type": "Number",
+                    "required": true,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": ""
+                },
+                "$repo": null
+            }
+        }
+    },
+
     "search": {
         "issues": {
             "url": "/search/issues",


### PR DESCRIPTION
NOTE: [Upload release asset](https://developer.github.com/v3/repos/releases/#upload-a-release-asset) is not implemented.

It's unclear how you'd like this implemented. It uses a different URL which means some how
the hosts address needs to change for this upload. It also has to send a potentially large
file meaning the file should probably be streamed, rather than passing the entire binary
blob to the function call.
