### PR TITLE
Add a headers field to the config so you can set user-agent globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ var github = new GitHubApi({
     protocol: "https",
     host: "github.my-GHE-enabled-company.com",
     pathPrefix: "/api/v3", // for some GHEs
-    timeout: 5000
+    timeout: 5000,
+    headers: {
+        "user-agent": "My-Cool-GitHub-App",  // GitHub requests a unique user agent
+    },
 });
 github.user.getFollowingFromUser({
     // optional:

--- a/index.js
+++ b/index.js
@@ -173,6 +173,7 @@ var Url = require("url");
  *      }
  **/
 var Client = module.exports = function(config) {
+    config.headers = config.headers || {};
     this.config = config;
     this.debug = Util.isTrue(config.debug);
 
@@ -714,13 +715,13 @@ var Client = module.exports = function(config) {
             }
         }
 
-        if (!msg.headers)
-            msg.headers = {};
-        Object.keys(msg.headers).forEach(function(header) {
-            var headerLC = header.toLowerCase();
-            if (self.requestHeaders.indexOf(headerLC) == -1)
-                return;
-            headers[headerLC] = msg.headers[header];
+        [msg.headers || {}, this.config.headers].forEach(function(newHeaders) {
+          Object.keys(newHeaders).forEach(function(header) {
+              var headerLC = header.toLowerCase();
+              if (self.requestHeaders.indexOf(headerLC) == -1)
+                  return;
+              headers[headerLC] = newHeaders[header];
+          });
         });
         if (!headers["user-agent"])
             headers["user-agent"] = "NodeJS HTTP Client";


### PR DESCRIPTION
GitHub [requests that app set a specific user agent](https://developer.github.com/v3/#user-agent-required) so they can track apps down.

As it is you'd have to set that header manually on every API call otherwise all apps will be reported as "NodeJS HTTP Client" which is not very nice to github.

This change makes it so you can set that header once when you create the API.

I'd almost think you should require it and fail if it's not set since that would help enforce Github's request but this was the simplest most generic change I could think of.
