### PR TITLE
bump version to v0.2.3

### DIFF
--- a/api/v3.0.0/markdown.js
+++ b/api/v3.0.0/markdown.js
@@ -37,17 +37,10 @@ var markdown = module.exports = {
             if (err)
                 return self.sendError(err, null, msg, callback);
 
-            var ret = {};
-            ret.meta = ret.meta || {};
-
-            try {
-                ret.body = res.data && JSON.parse(JSON.stringify(res.data));
-            }
-            catch (ex) {
-                if (callback)
-                    callback(new error.InternalServerError(ex.message), res);
-                return;
-            }
+            var ret = {
+                body: res.data,
+                meta: {}
+            };
 
             ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
                 if (res.headers[header]) {

--- a/api/v3.0.0/markdown.js
+++ b/api/v3.0.0/markdown.js
@@ -37,9 +37,11 @@ var markdown = module.exports = {
             if (err)
                 return self.sendError(err, null, msg, callback);
 
-            var ret;
+            var ret = {};
+            ret.meta = ret.meta || {};
+
             try {
-                ret = res.data && JSON.parse(res.data);
+                ret.body = res.data && JSON.parse(JSON.stringify(res.data));
             }
             catch (ex) {
                 if (callback)
@@ -47,13 +49,10 @@ var markdown = module.exports = {
                 return;
             }
 
-            if (!ret)
-                ret = {};
-            if (!ret.meta)
-                ret.meta = {};
             ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
-                if (res.headers[header])
+                if (res.headers[header]) {
                     ret.meta[header] = res.headers[header];
+                }
             });
 
             if (callback)

--- a/api/v3.0.0/markdownTest.js
+++ b/api/v3.0.0/markdownTest.js
@@ -35,7 +35,11 @@ describe("[markdown]", function() {
             },
             function(err, res) {
                 Assert.equal(err, null);
-                console.log(res);
+                Assert.ok(res.meta.status);
+                Assert.ok(res.meta['x-ratelimit-limit']);
+                Assert.ok(res.meta['x-ratelimit-remaining']);
+                Assert.ok(res.meta['x-ratelimit-reset']);
+                Assert.equal(res.body, "<p>Hello world <a href=\"https://github.com/github/linguist/issues/1\" class=\"issue-link\" title=\"Binary detection issues on extensionless files\">github/linguist#1</a> <strong>cool</strong>, and #1!</p>");
                 next();
             }
         );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name" : "github",
-    "version" : "0.2.2",
+    "version" : "0.2.3",
     "description" : "NodeJS wrapper for the GitHub API",
     "author": "Mike de Boer <info@mikedeboer.nl>",
     "contributors": [

--- a/seed.yml
+++ b/seed.yml
@@ -2,4 +2,4 @@
   name: node-github
   description: NodeJS wrapper for the GitHub API
   tags: git github web
-  version: 0.2.2
+  version: 0.2.3


### PR DESCRIPTION
It would be great if you could bump the version on npm, so I can use the feature I submitted pull request #189 for through the npm package instead of installing through git.
