### PR TITLE
Updated the routes for Statuses

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -1544,7 +1544,17 @@
 
     "statuses": {
         "get": {
-            "url": "/repos/:user/:repo/statuses/:sha",
+            "url": "/repos/:user/:repo/commits/:sha/statuses",
+            "method": "GET",
+            "params": {
+                "$user": null,
+                "$repo": null,
+                "$sha": null
+            }
+        },
+
+        "get-combined": {
+            "url": "/repos/:user/:repo/commits/:sha/status",
             "method": "GET",
             "params": {
                 "$user": null,
@@ -1580,6 +1590,13 @@
                     "validation": "",
                     "invalidmsg": "",
                     "description": "Short description of the status."
+                },
+                "context": {
+                    "type": "String",
+                    "required": false,
+                    "validation": "",
+                    "invalidmsg": "",
+                    "description": "A string label to differentiate this status from the status of other systems."
                 }
             }
         }

--- a/api/v3.0.0/statuses.js
+++ b/api/v3.0.0/statuses.js
@@ -62,6 +62,48 @@ var statuses = module.exports = {
     };
 
     /** section: github
+     *  statuses#getCombined(msg, callback) -> null
+     *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
+     *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
+     *
+     *  ##### Params on the `msg` object:
+     *
+     *  - headers (Object): Optional. Key/ value pair of request headers to pass along with the HTTP request. Valid headers are: 'If-Modified-Since', 'If-None-Match', 'Cookie', 'User-Agent', 'Accept', 'X-GitHub-OTP'.
+     *  - user (String): Required. 
+     *  - repo (String): Required. 
+     *  - sha (String): Required. 
+     **/
+    this.getCombined = function(msg, block, callback) {
+        var self = this;
+        this.client.httpSend(msg, block, function(err, res) {
+            if (err)
+                return self.sendError(err, null, msg, callback);
+
+            var ret;
+            try {
+                ret = res.data && JSON.parse(res.data);
+            }
+            catch (ex) {
+                if (callback)
+                    callback(new error.InternalServerError(ex.message), res);
+                return;
+            }
+
+            if (!ret)
+                ret = {};
+            if (!ret.meta)
+                ret.meta = {};
+            ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-oauth-scopes", "link", "location", "last-modified", "etag", "status"].forEach(function(header) {
+                if (res.headers[header])
+                    ret.meta[header] = res.headers[header];
+            });
+
+            if (callback)
+                callback(null, ret);
+        });
+    };
+
+    /** section: github
      *  statuses#create(msg, callback) -> null
      *      - msg (Object): Object that contains the parameters and their values to be sent to the server.
      *      - callback (Function): function to call when the request is finished with an error as first argument and result data as second argument.
@@ -75,6 +117,7 @@ var statuses = module.exports = {
      *  - state (String): Required. State of the status - can be one of pending, success, error, or failure. Validation rule: ` ^(pending|success|error|failure)$ `.
      *  - target_url (String): Optional. Target url to associate with this status. This URL will be linked from the GitHub UI to allow users to easily see the ‘source’ of the Status.
      *  - description (String): Optional. Short description of the status.
+     *  - context (String): Optional. A string label to differentiate this status from the status of other systems.
      **/
     this.create = function(msg, block, callback) {
         var self = this;

--- a/api/v3.0.0/statusesTest.js
+++ b/api/v3.0.0/statusesTest.js
@@ -26,8 +26,23 @@ describe("[statuses]", function() {
         });
     });
 
-    it("should successfully execute GET /repos/:user/:repo/statuses/:sha (get)",  function(next) {
+    it("should successfully execute GET /repos/:user/:repo/commits/:sha/statuses (get)",  function(next) {
         client.statuses.get(
+            {
+                user: "mikedeboer",
+                repo: "node-github",
+                sha: "30d607d8fd8002427b61273f25d442c233cbf631"
+            },
+            function(err, res) {
+                Assert.equal(err, null);
+                // other assertions go here
+                next();
+            }
+        );
+    });
+
+    it("should successfully execute GET /repos/:user/:repo/commits/:sha/status (get)",  function(next) {
+        client.statuses.getCombined(
             {
                 user: "mikedeboer",
                 repo: "node-github",


### PR DESCRIPTION
The routes for the Statuses section have been updated to reflect the
current version at https://developer.github.com/v3/repos/statuses/

Please review :)
