### PR TITLE
don't use beta API by default.

### DIFF
--- a/api/v3.0.0/routes.json
+++ b/api/v3.0.0/routes.json
@@ -8,7 +8,7 @@
             "port": 443,
             "dateFormat": "YYYY-MM-DDTHH:MM:SSZ",
             "requestFormat": "json",
-            "requestMedia": "application/vnd.github.beta+json"
+            "requestMedia": "application/vnd.github.v3+json"
         },
         "response-headers": [
             "X-RateLimit-Limit",


### PR DESCRIPTION
The default request media is set to use the beta API. This is causing some endpoints to return unexpected JSON, e.g. `/user/emails`.
