### PR TITLE
undo includePreview config flag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ var github = new GitHubApi({
         "user-agent": "My-Cool-GitHub-App" // GitHub is happy with a unique user agent
     },
     followRedirects: false, // default: true; there's currently an issue with non-get redirects, so allow ability to disable follow-redirects
-    includePreview: true // default: false; includes accept headers to allow use of stuff under preview period
 });
 github.users.getFollowingForUser({
     // optional:
@@ -150,6 +149,10 @@ github.authorization.create({
     }
 });
 ```
+
+## Preview
+
+Some endpoints are in a preview period and require a custom `Accept` header. See https://developer.github.com/changes/ or [routes.json](https://github.com/mikedeboer/node-github/blob/master/lib/routes.json#L13).
 
 ## Update docs/tests
 

--- a/doc/apidoc.js
+++ b/doc/apidoc.js
@@ -448,7 +448,7 @@ github.authorization.delete({ ... });
 /**
  * @api {delete} /applications/grants/:id deleteGrant
  * @apiName deleteGrant
- * @apiDescription Delete a grant. Requires includePreview: true in config.
+ * @apiDescription Delete a grant. In preview period. See README.
  * @apiGroup authorization
  *
  * @apiParam {String} id  
@@ -482,7 +482,7 @@ github.authorization.getAll({ ... });
 /**
  * @api {get} /applications/grants/:id getGrant
  * @apiName getGrant
- * @apiDescription Get a single grant. Requires includePreview: true in config.
+ * @apiDescription Get a single grant. In preview period. See README.
  * @apiGroup authorization
  *
  * @apiParam {String} id  
@@ -495,7 +495,7 @@ github.authorization.getGrant({ ... });
 /**
  * @api {get} /applications/grants getGrants
  * @apiName getGrants
- * @apiDescription List your grants. Requires includePreview: true in config.
+ * @apiDescription List your grants. In preview period. See README.
  * @apiGroup authorization
  *
  * @apiParam {Number} [page]  Page number of the results to fetch.
@@ -1131,7 +1131,7 @@ github.issues.checkAssignee({ ... });
  * @apiParam {String} [assignee]  Login for the user that this issue should be assigned to.
  * @apiParam {Number} [milestone]  Milestone to associate this issue with.
  * @apiParam {Json} [labels]  Array of strings - Labels to associate with this issue.
- * @apiParam {Array} [assignees]  Logins for Users to assign to this issue. NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise. Requires includePreview: true in config.
+ * @apiParam {Array} [assignees]  Logins for Users to assign to this issue. NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise. In preview period. See README.
  * @apiExample {js} ex:
 github.issues.create({ ... });
  */
@@ -1234,7 +1234,7 @@ github.issues.deleteMilestone({ ... });
  * @apiParam {String} [state=open]  open or closed
  * @apiParam {Number} [milestone]  Milestone to associate this issue with.
  * @apiParam {Json} [labels]  Array of strings - Labels to associate with this issue.
- * @apiParam {Array} [assignees]  Logins for Users to assign to this issue. Pass one or more user logins to replace the set of assignees on this Issue. .Send an empty array ([]) to clear all assignees from the Issue. NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise. Requires includePreview: true in config.
+ * @apiParam {Array} [assignees]  Logins for Users to assign to this issue. Pass one or more user logins to replace the set of assignees on this Issue. .Send an empty array ([]) to clear all assignees from the Issue. NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise. In preview period. See README.
  * @apiExample {js} ex:
 github.issues.edit({ ... });
  */
@@ -1386,7 +1386,7 @@ github.issues.getEventsForRepo({ ... });
 /**
  * @api {get} /repos/:user/:repo/issues/:number/timeline getEventsTimeline
  * @apiName getEventsTimeline
- * @apiDescription List events for an issue. Requires includePreview: true in config.
+ * @apiDescription List events for an issue. In preview period. See README.
  * @apiGroup issues
  *
  * @apiParam {String} user  
@@ -2482,8 +2482,8 @@ github.pullRequests.getFiles({ ... });
  * @apiParam {Number} number  
  * @apiParam {String} [commit_message]  Extra detail to append to automatic commit message.
  * @apiParam {String} [sha]  SHA that pull request head must match to allow merge
- * @apiParam {String} [commit_title]  Title for the automatic commit message. Requires includePreview: true in config.
- * @apiParam {Boolean} [squash]  Commit a single commit to the head branch. Requires includePreview: true in config.
+ * @apiParam {String} [commit_title]  Title for the automatic commit message. In preview period. See README.
+ * @apiParam {Boolean} [squash]  Commit a single commit to the head branch. In preview period. See README.
  * @apiExample {js} ex:
 github.pullRequests.merge({ ... });
  */
@@ -2507,7 +2507,7 @@ github.pullRequests.update({ ... });
 /**
  * @api {post} /repos/:user/:repo/comments/:id/reactions createForCommitComment
  * @apiName createForCommitComment
- * @apiDescription Create reaction for a commit comment.
+ * @apiDescription Create reaction for a commit comment. In preview period. See README.
  * @apiGroup reactions
  *
  * @apiParam {String} user  
@@ -2521,7 +2521,7 @@ github.reactions.createForCommitComment({ ... });
 /**
  * @api {post} /repos/:user/:repo/issues/:number/reactions createForIssue
  * @apiName createForIssue
- * @apiDescription Create reaction for an issue.
+ * @apiDescription Create reaction for an issue. In preview period. See README.
  * @apiGroup reactions
  *
  * @apiParam {String} user  
@@ -2535,7 +2535,7 @@ github.reactions.createForIssue({ ... });
 /**
  * @api {post} /repos/:user/:repo/issues/comments/:id/reactions createForIssueComment
  * @apiName createForIssueComment
- * @apiDescription Create reaction for an issue comment.
+ * @apiDescription Create reaction for an issue comment. In preview period. See README.
  * @apiGroup reactions
  *
  * @apiParam {String} user  
@@ -2549,7 +2549,7 @@ github.reactions.createForIssueComment({ ... });
 /**
  * @api {post} /repos/:user/:repo/pulls/comments/:id/reactions createForPullRequestReviewComment
  * @apiName createForPullRequestReviewComment
- * @apiDescription Create reaction for a pull request review comment.
+ * @apiDescription Create reaction for a pull request review comment. In preview period. See README.
  * @apiGroup reactions
  *
  * @apiParam {String} user  
@@ -2563,7 +2563,7 @@ github.reactions.createForPullRequestReviewComment({ ... });
 /**
  * @api {delete} /reactions/:id delete
  * @apiName delete
- * @apiDescription Delete a reaction.
+ * @apiDescription Delete a reaction. In preview period. See README.
  * @apiGroup reactions
  *
  * @apiParam {String} id  
@@ -2574,7 +2574,7 @@ github.reactions.delete({ ... });
 /**
  * @api {get} /repos/:user/:repo/comments/:id/reactions getForCommitComment
  * @apiName getForCommitComment
- * @apiDescription List reactions for a commit comment.
+ * @apiDescription List reactions for a commit comment. In preview period. See README.
  * @apiGroup reactions
  *
  * @apiParam {String} user  
@@ -2588,7 +2588,7 @@ github.reactions.getForCommitComment({ ... });
 /**
  * @api {get} /repos/:user/:repo/issues/:number/reactions getForIssue
  * @apiName getForIssue
- * @apiDescription List reactions for an issue.
+ * @apiDescription List reactions for an issue. In preview period. See README.
  * @apiGroup reactions
  *
  * @apiParam {String} user  
@@ -2602,7 +2602,7 @@ github.reactions.getForIssue({ ... });
 /**
  * @api {get} /repos/:user/:repo/issues/comments/:id/reactions getForIssueComment
  * @apiName getForIssueComment
- * @apiDescription List reactions for an issue comment.
+ * @apiDescription List reactions for an issue comment. In preview period. See README.
  * @apiGroup reactions
  *
  * @apiParam {String} user  
@@ -2616,7 +2616,7 @@ github.reactions.getForIssueComment({ ... });
 /**
  * @api {get} /repos/:user/:repo/pulls/comments/:id/reactions getForPullRequestReviewComment
  * @apiName getForPullRequestReviewComment
- * @apiDescription List reactions for a pull request review comment.
+ * @apiDescription List reactions for a pull request review comment. In preview period. See README.
  * @apiGroup reactions
  *
  * @apiParam {String} user  

--- a/examples/getIssuesForRepo.js
+++ b/examples/getIssuesForRepo.js
@@ -5,7 +5,9 @@ var testAuth = require("./../testAuth.json");
 
 var github = new Client({
     debug: false,
-    includePreview: true
+    headers: {
+        "Accept": "application/vnd.github.squirrel-girl-preview"
+    }
 });
 
 github.authenticate({

--- a/examples/getReactionsForIssue.js
+++ b/examples/getReactionsForIssue.js
@@ -5,7 +5,9 @@ var testAuth = require("./../testAuth.json");
 
 var github = new Client({
     debug: true,
-    includePreview: true
+    headers: {
+        "Accept": "application/vnd.github.squirrel-girl-preview"
+    }
 });
 
 github.authenticate({

--- a/examples/lockIssue.js
+++ b/examples/lockIssue.js
@@ -5,7 +5,9 @@ var testAuth = require("./../testAuth.json");
 
 var github = new Client({
     debug: true,
-    includePreview: true
+    headers: {
+        "Accept": "application/vnd.github.the-key-preview"
+    }
 });
 
 github.authenticate({

--- a/examples/paginationCustomHeaders.js
+++ b/examples/paginationCustomHeaders.js
@@ -4,8 +4,7 @@ var Client = require("./../lib/index");
 var testAuth = require("./../testAuth.json");
 
 var github = new Client({
-    debug: true,
-    includePreview: true
+    debug: true
 });
 
 github.authenticate({

--- a/lib/index.js
+++ b/lib/index.js
@@ -679,10 +679,8 @@ var Client = module.exports = function(config) {
         if (!headers["user-agent"])
             headers["user-agent"] = "NodeJS HTTP Client";
 
-        if (!("Accept" in headers))
-            headers["Accept"] = this.config.requestMedia || this.constants.requestMedia;
-        if (self.config.includePreview === true)
-            headers["Accept"] += "," + this.constants.previewRequestMedia.join(',');
+        if (!("accept" in headers))
+            headers["accept"] = this.config.requestMedia || this.constants.requestMedia;
 
         var options = {
             host: host,

--- a/lib/routes.json
+++ b/lib/routes.json
@@ -423,7 +423,7 @@
                 "$page": null,
                 "$per_page": null
             },
-            "description": "List your grants. Requires includePreview: true in config."
+            "description": "List your grants. In preview period. See README."
         },
         
         "get-grant": {
@@ -434,7 +434,7 @@
                 "$page": null,
                 "$per_page": null
             },
-            "description": "Get a single grant. Requires includePreview: true in config."
+            "description": "Get a single grant. In preview period. See README."
         },
         
         "delete-grant": {
@@ -443,7 +443,7 @@
             "params": {
                 "$id": null
             },
-            "description": "Delete a grant. Requires includePreview: true in config."
+            "description": "Delete a grant. In preview period. See README."
         },
         
         "get-all": {
@@ -1740,7 +1740,7 @@
                     "required": false,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "Logins for Users to assign to this issue. NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise. Requires includePreview: true in config."
+                    "description": "Logins for Users to assign to this issue. NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise. In preview period. See README."
                 }
             },
             "description": "Create an issue"
@@ -1801,7 +1801,7 @@
                     "required": false,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "Logins for Users to assign to this issue. Pass one or more user logins to replace the set of assignees on this Issue. .Send an empty array ([]) to clear all assignees from the Issue. NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise. Requires includePreview: true in config."
+                    "description": "Logins for Users to assign to this issue. Pass one or more user logins to replace the set of assignees on this Issue. .Send an empty array ([]) to clear all assignees from the Issue. NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise. In preview period. See README."
                 }
             },
             "description": "Edit an issue"
@@ -1972,7 +1972,7 @@
                 "$page": null,
                 "$per_page": null
             },
-            "description": "List events for an issue. Requires includePreview: true in config."
+            "description": "List events for an issue. In preview period. See README."
         },
 
         "get-events-for-repo": {
@@ -3154,14 +3154,14 @@
                     "required": false,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "Title for the automatic commit message. Requires includePreview: true in config."
+                    "description": "Title for the automatic commit message. In preview period. See README."
                 },
                 "squash": {
                     "type": "Boolean",
                     "required": false,
                     "validation": "",
                     "invalidmsg": "",
-                    "description": "Commit a single commit to the head branch. Requires includePreview: true in config."
+                    "description": "Commit a single commit to the head branch. In preview period. See README."
                 }
             },
             "description": "Merge a pull request (Merge Button)"
@@ -3287,7 +3287,7 @@
                     "description": "Indicates which type of reaction to return."
                 }
             },
-            "description": "List reactions for a commit comment."
+            "description": "List reactions for a commit comment. In preview period. See README."
         },
         
         "create-for-commit-comment": {
@@ -3305,7 +3305,7 @@
                     "description": "The reaction type."
                 }
             },
-            "description": "Create reaction for a commit comment."
+            "description": "Create reaction for a commit comment. In preview period. See README."
         },
         
         "get-for-issue": {
@@ -3323,7 +3323,7 @@
                     "description": "Indicates which type of reaction to return."
                 }
             },
-            "description": "List reactions for an issue."
+            "description": "List reactions for an issue. In preview period. See README."
         },
         
         "create-for-issue": {
@@ -3341,7 +3341,7 @@
                     "description": "The reaction type."
                 }
             },
-            "description": "Create reaction for an issue."
+            "description": "Create reaction for an issue. In preview period. See README."
         },
         
         "get-for-issue-comment": {
@@ -3359,7 +3359,7 @@
                     "description": "Indicates which type of reaction to return."
                 }
             },
-            "description": "List reactions for an issue comment."
+            "description": "List reactions for an issue comment. In preview period. See README."
         },
         
         "create-for-issue-comment": {
@@ -3377,7 +3377,7 @@
                     "description": "The reaction type."
                 }
             },
-            "description": "Create reaction for an issue comment."
+            "description": "Create reaction for an issue comment. In preview period. See README."
         },
         
         "get-for-pull-request-review-comment": {
@@ -3395,7 +3395,7 @@
                     "description": "Indicates which type of reaction to return."
                 }
             },
-            "description": "List reactions for a pull request review comment."
+            "description": "List reactions for a pull request review comment. In preview period. See README."
         },
         
         "create-for-pull-request-review-comment": {
@@ -3413,7 +3413,7 @@
                     "description": "The reaction type."
                 }
             },
-            "description": "Create reaction for a pull request review comment."
+            "description": "Create reaction for a pull request review comment. In preview period. See README."
         },
         
         "delete": {
@@ -3422,7 +3422,7 @@
             "params": {
                 "$id": null
             },
-            "description": "Delete a reaction."
+            "description": "Delete a reaction. In preview period. See README."
         }
     },
 


### PR DESCRIPTION
For endpoints in the preview period, the custom Accept header needs to
be the first value, so enabling includePreview and throwing in all the
accept headers for preview endpoints does not work. The solution is to
just include custom header with the necessary Accept header val for the
given preview endpoint you're using.

resolves #355
