### PR TITLE
fix(typescript): return type for `octokit.hook.wrap` callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33704,7 +33704,7 @@ export class Octokit {
           options: Octokit.HookOptions
         ) => Promise<Octokit.Response<any>>,
         options: Octokit.HookOptions
-      ) => void
+      ) => Promise<Octokit.Response<any>>
     ): void;
   };
 

--- a/scripts/update-endpoints/templates/index.d.ts.tpl
+++ b/scripts/update-endpoints/templates/index.d.ts.tpl
@@ -320,7 +320,7 @@ export class Octokit {
     before(name: string, callback: (options: Octokit.HookOptions) => void): void
     after(name: string, callback: (response: Octokit.Response<any>, options: Octokit.HookOptions) => void): void
     error(name: string, callback: (error: Octokit.HookError, options: Octokit.HookOptions) => void): void
-    wrap(name: string, callback: (request: (options: Octokit.HookOptions) => Promise<Octokit.Response<any>>, options: Octokit.HookOptions) => void): void
+    wrap(name: string, callback: (request: (options: Octokit.HookOptions) => Promise<Octokit.Response<any>>, options: Octokit.HookOptions) => Promise<Octokit.Response<any>>): void
   }
 
   static plugin(plugin: Octokit.Plugin | Octokit.Plugin[]): Octokit.Static;


### PR DESCRIPTION
fixes bug mentioned in https://github.com/octokit/rest.js/discussions/1769

@douglascayers: could you check if that pull request resolves your problem?
