### PR TITLE
docs(README): clarify the difference between `octokit.request` and the `octokit.rest.*` endpoint methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,32 @@ Learn more about [how authentication strategies work](https://github.com/octokit
 
 ### REST API
 
+There are two ways of using the REST API, the [`octokit.rest.*` endpoint methods](#endpoint-methods) and [`octokit.request`](#arbitrary-requests). Both work exactly the same, `octokit.rest.*` are just convenience methods that use `octokit.request` internally.
+
+For example
+
+```js
+await octokit.rest.issues.create({
+  owner: "octocat",
+  repo: "hello-world",
+  title: "Hello, world!",
+  body: "I created this issue using Octokit!",
+});
+```
+
+Is the same as
+
+```js
+await octokit.request("POST /repos/{owner}/{repo}/issues", {
+  owner: "octocat",
+  repo: "hello-world",
+  title: "Hello, world!",
+  body: "I created this issue using Octokit!",
+});
+```
+
+`octokit.request` can be used to send requests to other domains by passing a full URL. It can also be used to send requests to endpoints that are not (yet) documented on [GitHub's REST API documentation](https://docs.github.com/rest).
+
 #### Endpoint methods
 
 **plugin**: [`@octokit/plugin-rest-endpoint-methods`](https://github.com/octokit/plugin-rest-endpoint-methods.js/#readme).

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The `octokit` package integrates the three main Octokit libraries
   - [Constructor options](#constructor-options)
   - [Authentication](#authentication)
   - [REST API](#rest-api)
-    - [Arbitrary requests](#arbitrary-requests)
     - [Endpoint methods](#endpoint-methods)
+    - [Arbitrary requests](#arbitrary-requests)
     - [Pagination](#pagination)
     - [Media Type previews and formats](#media-type-previews-and-formats)
   - [GraphQL API queries](#graphql-api-queries)
@@ -362,6 +362,27 @@ Learn more about [how authentication strategies work](https://github.com/octokit
 
 ### REST API
 
+#### Endpoint methods
+
+**plugin**: [`@octokit/plugin-rest-endpoint-methods`](https://github.com/octokit/plugin-rest-endpoint-methods.js/#readme).
+
+Every REST API endpoint has an according method for better code readability and developer convenience.
+
+Example: [Create an issue](https://docs.github.com/en/rest/reference/issues#create-an-issue)
+
+```js
+await octokit.rest.issues.create({
+  owner: "octocat",
+  repo: "hello-world",
+  title: "Hello, world!",
+  body: "I created this issue using Octokit!",
+});
+```
+
+The REST API endpoint methods are generated automatically from [GitHub's OpenAPI specification](https://github.com/github/rest-api-description/). We track operation ID or parameter name changes in order to implement deprecation warnings and reduce the frequency of breaking changes.
+
+Every endpoint method is an instance of `octokit.request` with defaults set, so it supports the same parameters as well as the `.endpoint()` API.
+
 #### Arbitrary requests
 
 **standalone method**: [`@octokit/request`](https://github.com/octokit/request.js#readme)
@@ -390,27 +411,6 @@ The 1st argument is the REST API route as listed in GitHub's API documentation. 
 See the standalone [`@octokit/request`](https://github.com/octokit/request.js#readme) module for more details on the `.request()` APIs.
 
 If you only need the request options, but want to send the actual request using your own method, use `octokit.request.endpoint(route, parameters)`. See the standalone [`@octokit/endpoint`](https://github.com/octokit/endpoint.js#readme) module for more details on the `.endpoint()` APIs.
-
-#### Endpoint methods
-
-**plugin**: [`@octokit/plugin-rest-endpoint-methods`](https://github.com/octokit/plugin-rest-endpoint-methods.js/#readme).
-
-Every REST API endpoint has an according method for better code readability and developer convenience.
-
-Example: [Create an issue](https://docs.github.com/en/rest/reference/issues#create-an-issue)
-
-```js
-await octokit.rest.issues.create({
-  owner: "octocat",
-  repo: "hello-world",
-  title: "Hello, world!",
-  body: "I created this issue using Octokit!",
-});
-```
-
-The REST API endpoint methods are generated automatically from [GitHub's OpenAPI specification](https://github.com/github/rest-api-description/). We track operation ID or parameter name changes in order to implement deprecation warnings and reduce the frequency of breaking changes.
-
-Every endpoint method is an instance of `octokit.request` with defaults set, so it supports the same parameters as well as the `.endpoint()` API.
 
 #### Pagination
 


### PR DESCRIPTION


-----
[View rendered README.md](https://github.com/octokit/octokit.js/blob/clarify-rest/README.md)