### PR TITLE
docs(readme): missing .rest in app example

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,11 +332,11 @@ const octokit = new Octokit({
 // authenticates as app based on request URLs
 const {
   data: { slug },
-} = await octokit.apps.getAuthenticated();
+} = await octokit.rest.apps.getAuthenticated();
 
 // creates an installation access token as needed
 // assumes that installationId 123 belongs to @octocat, otherwise the request will fail
-await octokit.issues.create({
+await octokit.rest.issues.create({
   owner: "octocat",
   repo: "hello-world",
   title: "Hello world from " + slug,


### PR DESCRIPTION
I tried to copy/paste the example and it didn't work. Adding `.rest` seems to work !

-----
[View rendered README.md](https://github.com/christophehurpeau/octokit.js/blob/patch-1/README.md)