### PR TITLE
ci: add NodeJS 16 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: ["12", "14"]
+        node_version: ["12", "14", "16"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
NodeJS v16 was just released today