### PR TITLE
fix(README): correct typo in the spelling of "graphql"

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ Learn more about [Media type formats](https://docs.github.com/en/rest/overview/m
 
 ### GraphQL API queries
 
-**standalone method**: [`@octokit/gpraphql`](https://github.com/octokit/gpraphql.js#readme)
+**standalone method**: [`@octokit/graphql`](https://github.com/octokit/graphql.js#readme)
 
 Example: get the login of the authenticated user
 


### PR DESCRIPTION


-----
[View rendered README.md](https://github.com/tetov/octokit.js/blob/patch-1/README.md)