### PR TITLE
fix(README): Fix bad references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ const octokit = new Octokit({ auth: `personal-access-token123` });
 // Compare: https://docs.github.com/en/rest/reference/users#get-the-authenticated-user
 const {
   data: { login },
-} = await octokit.users.getAuthenticated();
+} = await octokit.rest.users.getAuthenticated();
 console.log("Hello, %s", login);
 ```
 
@@ -351,7 +351,7 @@ For example, to implement the above using `App`
 const app = new App({ appId, privateKey });
 const { data: slug } = await app.octokit.rest.apps.getAuthenticated();
 const { octokit } = await app.getInstallationOctokit(123);
-await octokit.issues.create({
+await octokit.rest.issues.create({
   owner: "octocat",
   repo: "hello-world",
   title: "Hello world from " + slug,


### PR DESCRIPTION
Hi!

I found a couple of references to undefined properties in the README when trying out this library, causing me to get stuck a bit longer than I'm proud of. This PR fixes them.

-----
[View rendered README.md](https://github.com/slarse/octokit.js/blob/fix-bad-references-in-readme/README.md)