### PR TITLE
Add documentation for using  with proxy servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,11 +368,11 @@ By default, the `Octokit` API client does not make use of the standard proxy ser
 For example, this would use a `proxy-agent` generated client that would configure the proxy based on the standard environment variables `http_proxy`, `https_proxy` and `no_proxy`:
 
 ```js
-import ProxyAgent  from "proxy-agent";
+import ProxyAgent from "proxy-agent";
 
 const octokit = new Octokit({
   request: {
-    agent: new ProxyAgent()
+    agent: new ProxyAgent(),
   },
 });
 ```
@@ -383,7 +383,7 @@ If you are writing a module that uses `Octokit` and is designed to be used by ot
 octokit.rest.repos.get({
   owner,
   repo,
-  request: { agent }
+  request: { agent },
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ await octokit.rest.issues.create({
 
 Learn more about [how authentication strategies work](https://github.com/octokit/authentication-strategies.js/#how-authentication-strategies-work) or how to [create your own](https://github.com/octokit/authentication-strategies.js/#create-your-own-octokit-authentication-strategy-module).
 
-### Proxy Servers
+### Proxy Servers (Node.js only)
 
 By default, the `Octokit` API client does not make use of the standard proxy server environment variables. To add support for proxy servers you will need to provide an https client that supports them such as [proxy-agent](https://www.npmjs.com/package/proxy-agent).
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The `octokit` package integrates the three main Octokit libraries
 - [`Octokit` API Client](#octokit-api-client)
   - [Constructor options](#constructor-options)
   - [Authentication](#authentication)
+  - [Proxy Servers](#proxy-servers)
   - [REST API](#rest-api)
     - [`octokit.rest` endpoint methods](#octokitrest-endpoint-methods)
     - [`octokit.request()`](#octokitrequest)
@@ -359,6 +360,32 @@ await octokit.rest.issues.create({
 ```
 
 Learn more about [how authentication strategies work](https://github.com/octokit/authentication-strategies.js/#how-authentication-strategies-work) or how to [create your own](https://github.com/octokit/authentication-strategies.js/#create-your-own-octokit-authentication-strategy-module).
+
+### Proxy Servers
+
+By default, the `Octokit` API client does not make use of the standard proxy server environment variables. To add support for proxy servers you will need to provide an https client that supports them such as [proxy-agent](https://www.npmjs.com/package/proxy-agent).
+
+For example, this would use a `proxy-agent` generated client that would configure the proxy based on the standard environment variables `http_proxy`, `https_proxy` and `no_proxy`:
+
+```js
+import ProxyAgent  from "proxy-agent";
+
+const octokit = new Octokit({
+  request: {
+    agent: new ProxyAgent()
+  },
+});
+```
+
+If you are writing a module that uses `Octokit` and is designed to be used by other people, you should ensure that consumers can provide an alternative agent for your `Octokit` or as a paramater to specific calls such as:
+
+```js
+octokit.rest.repos.get({
+  owner,
+  repo,
+  request: { agent }
+});
+```
 
 ### REST API
 


### PR DESCRIPTION
Following on from the discussions in https://github.com/octokit/action.js/issues/342, it would make sense to add some notes about using proxy server here.

Hopefully this should cover it.

-----
[View rendered README.md](https://github.com/steve-norman-rft/octokit.js/blob/proxy-docs/README.md)