### PR TITLE
fix(docs): correct proxy servers headline not rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `octokit` package integrates the three main Octokit libraries
 - [`Octokit` API Client](#octokit-api-client)
   - [Constructor options](#constructor-options)
   - [Authentication](#authentication)
-  - [Proxy Servers](#proxy-servers)
+  - [Proxy Servers](#proxy-servers-nodejs-only)
   - [REST API](#rest-api)
     - [`octokit.rest` endpoint methods](#octokitrest-endpoint-methods)
     - [`octokit.request()`](#octokitrequest)
@@ -361,7 +361,7 @@ await octokit.rest.issues.create({
 
 Learn more about [how authentication strategies work](https://github.com/octokit/authentication-strategies.js/#how-authentication-strategies-work) or how to [create your own](https://github.com/octokit/authentication-strategies.js/#create-your-own-octokit-authentication-strategy-module).
 
-### Proxy Servers (Node.js only)
+### Proxy Servers (Node.js only)
 
 By default, the `Octokit` API client does not make use of the standard proxy server environment variables. To add support for proxy servers you will need to provide an https client that supports them such as [proxy-agent](https://www.npmjs.com/package/proxy-agent).
 


### PR DESCRIPTION
Somehow the proxy servers headline was not rendered as headline ("wrong" space) and the anchor link in the table of contents was outdated.

-----
[View rendered README.md](https://github.com/bxt/octokit.js/blob/patch-1/README.md)