### PR TITLE
Revert "docs(README): fix "REST API" section links"

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ octokit.rest.repos.get({
 
 ### REST API
 
-There are two ways of using the GitHub REST API, the [`octokit.rest.*` endpoint methods](#octokitrest-endpoint-methods) and [`octokit.request`](#octokitrequest). Both act the same way, the `octokit.rest.*` methods are just added for convenience, they use `octokit.request` internally.
+There are two ways of using the GitHub REST API, the [`octokit.rest.*` endpoint methods](#endpoint-methods) and [`octokit.request`](#arbitrary-requests). Both act the same way, the `octokit.rest.*` methods are just added for convenience, they use `octokit.request` internally.
 
 For example
 


### PR DESCRIPTION
Reverts octokit/octokit.js#2181

-----
[View rendered README.md](https://github.com/swansoffie01/octokit.js/blob/revert-2181-fix-rest-section-links/README.md)