### PR TITLE
docs(README): fix "REST API" preview information

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,8 @@ const issues = await octokit.paginate(octokit.rest.issues.listForRepo, {
 
 #### Media Type previews and formats
 
+**Note**: The concept of _previews_ has been deprecated from REST API endpoints hosted via `api.github.com` but it still exists in GHE (GitHub Enterprise Server) version 3.2 and below. Instead of using _previews_ going forward, new features are now being tested using beta previews that users will have to opt-in to.
+
 Media type previews and formats can be set using `mediaType: { format, previews }` on every request. Required API previews are set automatically on the respective REST API endpoint methods.
 
 Example: retrieve the raw content of a `package.json` file
@@ -520,7 +522,7 @@ const { data } = octokit.rest.repos.getContent({
 console.log("topics on octocat/hello-world: %j", data.topics);
 ```
 
-Learn more about [Media type formats](https://docs.github.com/en/rest/overview/media-types) and [API previews](https://docs.github.com/en/rest/overview/api-previews).
+Learn more about [Media type formats](https://docs.github.com/en/rest/overview/media-types) and [previews](https://docs.github.com/en/enterprise-server@3.2/rest/overview/api-previews) used on GitHub Enterprise Server.
 
 ### GraphQL API queries
 

--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ const issues = await octokit.paginate(octokit.rest.issues.listForRepo, {
 
 #### Media Type previews and formats
 
-**Note**: The concept of _previews_ has been deprecated from REST API endpoints hosted via `api.github.com` but it still exists in GHE (GitHub Enterprise Server) version 3.2 and below. Instead of using _previews_ going forward, new features are now being tested using beta previews that users will have to opt-in to.
+**Note**: The concept of _preview headers_ has been deprecated from REST API endpoints hosted via `api.github.com` but it still exists in GHES (GitHub Enterprise Server) version 3.2 and below. Instead of using _preview headers_ going forward, new features are now being tested using beta previews that users will have to opt-in to.
 
 Media type previews and formats can be set using `mediaType: { format, previews }` on every request. Required API previews are set automatically on the respective REST API endpoint methods.
 


### PR DESCRIPTION
The information regarding previews was out of sync with what was done back in [October](https://github.blog/changelog/2021-10-14-rest-api-preview-promotions/).  Given that the REST API previews have been sunset for `api.github.com` but are still supported in GHES the link to the information about previews was out of date as well - so I updated that to reflect the preview info for Enterprise Server.

Note: this PR to the [octokit/handbook](https://github.com/octokit/handbook/pull/6) relates/details to this change as well.

-----
[View rendered README.md](https://github.com/nickfloyd/octokit.js/blob/update-preview-info/README.md)