### PR TITLE
fix: set correct user agent

### DIFF
--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -12,7 +12,7 @@ export const Octokit = OctokitCore.plugin(
   retry,
   throttling
 ).defaults({
-  userAgent: `octokit-rest.js/${VERSION}`,
+  userAgent: `octokit.js/${VERSION}`,
   throttle: {
     onRateLimit,
     onAbuseLimit,


### PR DESCRIPTION
@timrogers @nickfloyd I realized by chance that we set `octokit-rest.js` in the request header, which really should be `octokit.js`. That PR fixes it. But in case you want to run any analytics, beware that up till now all request sent using the `octokit` package look as if they were sent using [`@octokit/rest`](https://github.com/octokit/rest.js) package.
