### PR TITLE
ci: stop testing against NodeJS v12, start testing v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: ["12", "14", "16"]
+        node_version: 
+          - 14
+          - 16
+          - 18
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v12

**Merge this once all other octokit libraries have updated**