### PR TITLE
fix(README): `getInstallationOctokit()` doesn't need destructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ For example, to implement the above using `App`
 ```js
 const app = new App({ appId, privateKey });
 const { data: slug } = await app.octokit.rest.apps.getAuthenticated();
-const { octokit } = await app.getInstallationOctokit(123);
+const octokit = await app.getInstallationOctokit(123);
 await octokit.rest.issues.create({
   owner: "octocat",
   repo: "hello-world",


### PR DESCRIPTION
Hey ocktokit team!

I've been playing around with consuming webhooks from a Next.js app so I'm not using probot and I need to create octokit instances manually. I believe this part of the docs is not correct according to the types I'm getting and also taking a look to the source code here https://github.com/octokit/app.js/blob/master/src/get-installation-octokit.ts#L19

Thanks!

-----
[View rendered README.md](https://github.com/gimenete/rest.js/blob/patch-2/README.md)