### PR TITLE
chore: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ Webhook event requests are signed using the webhook secret, which is also part o
 
 The `app.webhooks.*` APIs provide methods to receiving, verifying, and handling webhook events.
 
-Exmaple: create a comment on new issues
+Example: create a comment on new issues
 
 ```js
 import { App, createNodeMiddleware } from "octokit";


### PR DESCRIPTION
"Exmaple" -> "Example"


-----
[View rendered README.md](https://github.com/bricker/octokit.js/blob/bcr/2207/typo/README.md)