### PR TITLE
fix: use "secondary" instead of "abuse" for rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ The time zone header will determine the timezone used for generating the timesta
 
 `Octokit` implements request throttling using [`@octokit/plugin-throttling`](https://github.com/octokit/plugin-throttling.js/#readme)
 
-By default, requests are retried once and warnings are logged in case hitting a rate or abuse limit
+By default, requests are retried once and warnings are logged in case of hitting a rate or secondary rate limit
 
 ```js
 {
@@ -290,9 +290,9 @@ By default, requests are retried once and warnings are logged in case hitting a 
       return true;
     }
   },
-  onAbuseLimit: (retryAfter, options, octokit) => {
+  onSecondaryRateLimit: (retryAfter, options, octokit) => {
     octokit.log.warn(
-      `Abuse detected for request ${options.method} ${options.url}`
+      `SecondaryRateLimit detected for request ${options.method} ${options.url}`
     );
 
     if (options.request.retryCount === 0) {

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -15,7 +15,7 @@ export const Octokit = OctokitCore.plugin(
   userAgent: `octokit.js/${VERSION}`,
   throttle: {
     onRateLimit,
-    onAbuseLimit,
+    onSecondaryRateLimit,
   },
 });
 
@@ -33,9 +33,9 @@ function onRateLimit(retryAfter: number, options: any, octokit: any) {
 }
 
 // istanbul ignore next no need to test internals of the throttle plugin
-function onAbuseLimit(retryAfter: number, options: any, octokit: any) {
+function onSecondaryRateLimit(retryAfter: number, options: any, octokit: any) {
   octokit.log.warn(
-    `Abuse detected for request ${options.method} ${options.url}`
+    `SecondaryRateLimit detected for request ${options.method} ${options.url}`
   );
 
   if (options.request.retryCount === 0) {


### PR DESCRIPTION
GitHub renamed `abuse limits` to `secondary rate limits` in 2021:
https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits

`@octokit/plugin-throttling` followed suit in March 2022, and released
version `3.6.0` with this new name (and deprecated `onAbuseLimit`):
octokit/plugin-throttling.js#455

This commit updates the codebase to use the new name.

-----
[View rendered README.md](https://github.com/nimadini/octokit.js/blob/main/README.md)