### PR TITLE
docs: Fix incorrect import in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,7 +787,7 @@ Example: create a GitHub server with express
 
 ```js
 import express from "express";
-import { App, createNodeMiddleware } from "octokit";
+import { OAuthApp, createNodeMiddleware } from "octokit";
 
 const expressApp = express();
 const octokitApp = new OAuthApp({


### PR DESCRIPTION
This code example is demonstrating and using OAuthApp, but it imports `App` instead.

-----
[View rendered README.md](https://github.com/tmcw/octokit.js/blob/patch-1/README.md)