### PR TITLE
docs(README): add missing `await` statement to `getContent()` call

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ Media type previews and formats can be set using `mediaType: { format, previews 
 Example: retrieve the raw content of a `package.json` file
 
 ```js
-const { data } = octokit.rest.repos.getContent({
+const { data } = await octokit.rest.repos.getContent({
   mediaType: {
     format: "raw",
   },
@@ -512,7 +512,7 @@ console.log("package name: %s", JSON.parse(data).name);
 Example: retrieve a repository with topics
 
 ```js
-const { data } = octokit.rest.repos.getContent({
+const { data } = await octokit.rest.repos.getContent({
   mediaType: {
     previews: ["mercy"],
   },


### PR DESCRIPTION
The examples for **octokit.rest.repos.getContent** did not have the **await** notation in them, making the example log "undefined" instead of the actual data.

Adding await will not assign the correct value to the data and display the value right.

-----
[View rendered README.md](https://github.com/robipop22/octokit.js/blob/main/README.md)