### PR TITLE
fix(revert): revert "fix(deps): update dependency @octokit/plugin-throttling to v6"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/plugin-paginate-rest": "^6.1.0",
         "@octokit/plugin-rest-endpoint-methods": "^7.1.1",
         "@octokit/plugin-retry": "^4.1.3",
-        "@octokit/plugin-throttling": "^6.0.0",
+        "@octokit/plugin-throttling": "^5.2.2",
         "@octokit/types": "^9.2.2"
       },
       "devDependencies": {
@@ -2017,15 +2017,15 @@
       }
     },
     "node_modules/@octokit/plugin-throttling": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.0.tgz",
-      "integrity": "sha512-RdKkzD8X/T17KJmEHTsZ5Ztj7WGNpxsJAIyR1bgvkoyar+cDrIRZMsP15r8JRB1QI/LN2F/stUs5/kMVaYXS9g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-5.2.3.tgz",
+      "integrity": "sha512-C9CFg9mrf6cugneKiaI841iG8DOv6P5XXkjmiNNut+swePxQ7RWEdAZRp5rJoE1hjsIqiYcKa/ZkOQ+ujPI39Q==",
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "bottleneck": "^2.15.3"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 14"
       },
       "peerDependencies": {
         "@octokit/core": "^4.0.0"
@@ -14641,9 +14641,9 @@
       }
     },
     "@octokit/plugin-throttling": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.0.tgz",
-      "integrity": "sha512-RdKkzD8X/T17KJmEHTsZ5Ztj7WGNpxsJAIyR1bgvkoyar+cDrIRZMsP15r8JRB1QI/LN2F/stUs5/kMVaYXS9g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-5.2.3.tgz",
+      "integrity": "sha512-C9CFg9mrf6cugneKiaI841iG8DOv6P5XXkjmiNNut+swePxQ7RWEdAZRp5rJoE1hjsIqiYcKa/ZkOQ+ujPI39Q==",
       "requires": {
         "@octokit/types": "^9.0.0",
         "bottleneck": "^2.15.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@octokit/plugin-paginate-rest": "^6.1.0",
     "@octokit/plugin-rest-endpoint-methods": "^7.1.1",
     "@octokit/plugin-retry": "^4.1.3",
-    "@octokit/plugin-throttling": "^6.0.0",
+    "@octokit/plugin-throttling": "^5.2.2",
     "@octokit/types": "^9.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This reverts commit 1ab74b02033e92e756a378966079458de0eb7cc4.

As this plugin requires Node 18, it's introduces a breaking change.

This commit reverts it. It has already been pushed on the `beta` branch