### PR TITLE
docs(README): fix closing `<code>` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `octokit` package integrates the three main Octokit libraries
 - [`Octokit` API Client](#octokit-api-client)
   - [Constructor options](#constructor-options)
   - [Authentication](#authentication)
-  - [Proxy Servers](#proxy-servers-nodejs-only)
+  - [Proxy Servers (Node.js only)](#proxy-servers-nodejs-only)
   - [REST API](#rest-api)
     - [`octokit.rest` endpoint methods](#octokitrest-endpoint-methods)
     - [`octokit.request()`](#octokitrequest)

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ const octokit = new Octokit({
         <code>authStrategy</code>
       </th>
       <td>
-        <code>Function<code>
+        <code>Function</code>
       </td>
       <td>
 


### PR DESCRIPTION
Before

<img width="657" alt="" src="https://github.com/octokit/octokit.js/assets/39992/3c510c12-0453-45da-8907-9e6632ae0a12">

After

<img width="622" alt="" src="https://github.com/octokit/octokit.js/assets/39992/3aed7334-63f1-4841-a3d1-e7f911fb8083">
