### PR TITLE
fix(deps): revert breaking changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@octokit/plugin-rest-endpoint-methods": "^7.1.1",
         "@octokit/plugin-retry": "^4.1.3",
         "@octokit/plugin-throttling": "^6.0.0",
-        "@octokit/types": "^10.0.0"
+        "@octokit/types": "^9.2.2"
       },
       "devDependencies": {
         "@octokit/tsconfig": "^2.0.0",
@@ -1783,14 +1783,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/@octokit/app/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
     "node_modules/@octokit/auth-app": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-4.0.13.tgz",
@@ -1810,14 +1802,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/@octokit/auth-app/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
     "node_modules/@octokit/auth-oauth-app": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-5.0.5.tgz",
@@ -1835,14 +1819,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
     "node_modules/@octokit/auth-oauth-device": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-4.0.4.tgz",
@@ -1855,14 +1831,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/auth-oauth-user": {
@@ -1881,14 +1849,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
     "node_modules/@octokit/auth-token": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.3.tgz",
@@ -1898,14 +1858,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/auth-token/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/auth-unauthenticated": {
@@ -1918,14 +1870,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/core": {
@@ -1945,14 +1889,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/@octokit/core/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
     "node_modules/@octokit/endpoint": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.5.tgz",
@@ -1966,14 +1902,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
     "node_modules/@octokit/graphql": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
@@ -1985,14 +1913,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/graphql/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/oauth-app": {
@@ -2037,18 +1957,10 @@
         "node": ">= 14"
       }
     },
-    "node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
     "node_modules/@octokit/openapi-types": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
+      "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "6.1.2",
@@ -2070,14 +1982,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
       "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
     },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.1.2.tgz",
@@ -2091,14 +1995,6 @@
       },
       "peerDependencies": {
         "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/plugin-retry": {
@@ -2116,14 +2012,6 @@
         "@octokit/core": ">=3"
       }
     },
-    "node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
     "node_modules/@octokit/plugin-throttling": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.1.0.tgz",
@@ -2137,14 +2025,6 @@
       },
       "peerDependencies": {
         "@octokit/core": "^4.0.0"
-      }
-    },
-    "node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/request": {
@@ -2176,22 +2056,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
-    "node_modules/@octokit/request/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
     "node_modules/@octokit/tsconfig": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
@@ -2199,11 +2063,11 @@
       "dev": true
     },
     "node_modules/@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
+      "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
       "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
+        "@octokit/openapi-types": "^17.2.0"
       }
     },
     "node_modules/@octokit/webhooks": {
@@ -2381,15 +2245,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
       "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
       "dev": true
-    },
-    "node_modules/@semantic-release/github/node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
     },
     "node_modules/@semantic-release/github/node_modules/aggregate-error": {
       "version": "4.0.1",
@@ -14728,16 +14583,6 @@
         "@octokit/plugin-paginate-rest": "^6.0.0",
         "@octokit/types": "^9.0.0",
         "@octokit/webhooks": "^10.0.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/auth-app": {
@@ -14754,16 +14599,6 @@
         "lru-cache": "^9.0.0",
         "universal-github-app-jwt": "^1.1.1",
         "universal-user-agent": "^6.0.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/auth-oauth-app": {
@@ -14778,16 +14613,6 @@
         "@types/btoa-lite": "^1.0.0",
         "btoa-lite": "^1.0.0",
         "universal-user-agent": "^6.0.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/auth-oauth-device": {
@@ -14799,16 +14624,6 @@
         "@octokit/request": "^6.0.0",
         "@octokit/types": "^9.0.0",
         "universal-user-agent": "^6.0.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/auth-oauth-user": {
@@ -14822,16 +14637,6 @@
         "@octokit/types": "^9.0.0",
         "btoa-lite": "^1.0.0",
         "universal-user-agent": "^6.0.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/auth-token": {
@@ -14840,16 +14645,6 @@
       "integrity": "sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==",
       "requires": {
         "@octokit/types": "^9.0.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/auth-unauthenticated": {
@@ -14859,16 +14654,6 @@
       "requires": {
         "@octokit/request-error": "^3.0.0",
         "@octokit/types": "^9.0.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/core": {
@@ -14883,16 +14668,6 @@
         "@octokit/types": "^9.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/endpoint": {
@@ -14903,16 +14678,6 @@
         "@octokit/types": "^9.0.0",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/graphql": {
@@ -14923,16 +14688,6 @@
         "@octokit/request": "^6.0.0",
         "@octokit/types": "^9.0.0",
         "universal-user-agent": "^6.0.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/oauth-app": {
@@ -14966,22 +14721,12 @@
         "@octokit/request-error": "^3.0.3",
         "@octokit/types": "^9.0.0",
         "btoa-lite": "^1.0.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/openapi-types": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
+      "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "6.1.2",
@@ -14996,14 +14741,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
           "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
-        },
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
         }
       }
     },
@@ -15014,16 +14751,6 @@
       "requires": {
         "@octokit/types": "^9.2.3",
         "deprecation": "^2.3.1"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/plugin-retry": {
@@ -15033,16 +14760,6 @@
       "requires": {
         "@octokit/types": "^9.0.0",
         "bottleneck": "^2.15.3"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/plugin-throttling": {
@@ -15052,16 +14769,6 @@
       "requires": {
         "@octokit/types": "^9.0.0",
         "bottleneck": "^2.15.3"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/request": {
@@ -15075,16 +14782,6 @@
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/request-error": {
@@ -15095,16 +14792,6 @@
         "@octokit/types": "^9.0.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
-        }
       }
     },
     "@octokit/tsconfig": {
@@ -15114,11 +14801,11 @@
       "dev": true
     },
     "@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
+      "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
       "requires": {
-        "@octokit/openapi-types": "^18.0.0"
+        "@octokit/openapi-types": "^17.2.0"
       }
     },
     "@octokit/webhooks": {
@@ -15253,15 +14940,6 @@
           "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
           "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
           "dev": true
-        },
-        "@octokit/types": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-          "dev": true,
-          "requires": {
-            "@octokit/openapi-types": "^18.0.0"
-          }
         },
         "aggregate-error": {
           "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/plugin-paginate-rest": "^6.1.0",
         "@octokit/plugin-rest-endpoint-methods": "^7.1.1",
         "@octokit/plugin-retry": "^4.1.3",
-        "@octokit/plugin-throttling": "^6.0.0",
+        "@octokit/plugin-throttling": "^5.2.2",
         "@octokit/types": "^9.2.2"
       },
       "devDependencies": {
@@ -2013,15 +2013,15 @@
       }
     },
     "node_modules/@octokit/plugin-throttling": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.1.0.tgz",
-      "integrity": "sha512-JqMbTiPC0sUSTsLQsdq3JVx1mx8UtTo5mwR80YqPXE93+XhevvSyOR1rO2Z+NbO/r0TK4hqFJSSi/9oIZBxZTg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-5.2.3.tgz",
+      "integrity": "sha512-C9CFg9mrf6cugneKiaI841iG8DOv6P5XXkjmiNNut+swePxQ7RWEdAZRp5rJoE1hjsIqiYcKa/ZkOQ+ujPI39Q==",
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "bottleneck": "^2.15.3"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 14"
       },
       "peerDependencies": {
         "@octokit/core": "^4.0.0"
@@ -2238,6 +2238,22 @@
       },
       "peerDependencies": {
         "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/plugin-throttling": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.0.tgz",
+      "integrity": "sha512-RdKkzD8X/T17KJmEHTsZ5Ztj7WGNpxsJAIyR1bgvkoyar+cDrIRZMsP15r8JRB1QI/LN2F/stUs5/kMVaYXS9g==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^4.0.0"
       }
     },
     "node_modules/@semantic-release/github/node_modules/@octokit/tsconfig": {
@@ -14763,9 +14779,9 @@
       }
     },
     "@octokit/plugin-throttling": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.1.0.tgz",
-      "integrity": "sha512-JqMbTiPC0sUSTsLQsdq3JVx1mx8UtTo5mwR80YqPXE93+XhevvSyOR1rO2Z+NbO/r0TK4hqFJSSi/9oIZBxZTg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-5.2.3.tgz",
+      "integrity": "sha512-C9CFg9mrf6cugneKiaI841iG8DOv6P5XXkjmiNNut+swePxQ7RWEdAZRp5rJoE1hjsIqiYcKa/ZkOQ+ujPI39Q==",
       "requires": {
         "@octokit/types": "^9.0.0",
         "bottleneck": "^2.15.3"
@@ -14929,6 +14945,16 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-5.0.0.tgz",
           "integrity": "sha512-mfON7q30NLdivuJktZuSP6I4/WPMjc/bcoxcHEWXd4esedHTqQpp3OUq2NzD2+M+J6o33zYDtJTl4qtRYh8HQQ==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^9.0.0",
+            "bottleneck": "^2.15.3"
+          }
+        },
+        "@octokit/plugin-throttling": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.0.tgz",
+          "integrity": "sha512-RdKkzD8X/T17KJmEHTsZ5Ztj7WGNpxsJAIyR1bgvkoyar+cDrIRZMsP15r8JRB1QI/LN2F/stUs5/kMVaYXS9g==",
           "dev": true,
           "requires": {
             "@octokit/types": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@octokit/plugin-rest-endpoint-methods": "^7.1.1",
     "@octokit/plugin-retry": "^4.1.3",
     "@octokit/plugin-throttling": "^6.0.0",
-    "@octokit/types": "^10.0.0"
+    "@octokit/types": "^9.2.2"
   },
   "devDependencies": {
     "@octokit/tsconfig": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@octokit/plugin-paginate-rest": "^6.1.0",
     "@octokit/plugin-rest-endpoint-methods": "^7.1.1",
     "@octokit/plugin-retry": "^4.1.3",
-    "@octokit/plugin-throttling": "^6.0.0",
+    "@octokit/plugin-throttling": "^5.2.2",
     "@octokit/types": "^9.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #2477 and reverts the dependency updates that prematurely dropped support for Node 14/16. 