### PR TITLE
Recommend `npm:` specifiers in Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `octokit` package integrates the three main Octokit libraries
 
 - **Complete**. All features of GitHub's platform APIs are covered.
 - **Prescriptive**. All recommended best practices are implemented.
-- **Universal**. Works in all modern browsers, [Node.js](https://nodejs.org/), and [Deno](https://deno.land/).
+- **Universal**. Works in all modern browsers, [Node.js](https://nodejs.org/), and [Deno](https://deno.com/).
 - **Tested**. All libraries have a 100% test coverage.
 - **Typed**. All libraries have extensive TypeScript declarations.
 - **Decomposable**. Use only the code you need. You can build your own Octokit in only a few lines of code or use the underlying static methods. Make your own tradeoff between functionality and bundle size.
@@ -69,10 +69,10 @@ import { Octokit, App } from "https://esm.sh/octokit";
 <tr><th>
 Deno
 </th><td width=100%>
-Load <code>octokit</code> directly from <a href="https://esm.sh">esm.sh</a>
+Load <code>octokit</code> directly using <a href="https://docs.deno.com/runtime/manual/node/npm_specifiers"><code>npm:</code> specifiers</a> 
         
 ```ts
-import { Octokit, App } from "https://esm.sh/octokit?dts";
+import { Octokit, App } from "npm:octokit";
 ```
 
 </td></tr>


### PR DESCRIPTION


----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Use `esm.sh` for importing NPM modules in Deno 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Recommend using `npm:` specifiers in Deno, as this is the easiest way to use NPM packages in Deno, and works well with lockfiles: https://docs.deno.com/runtime/manual/node/

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

