### PR TITLE
fix: updates app.js for the handling of an error being thrown by the verify method in webhooks.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@octokit/app": "^14.0.0",
+        "@octokit/app": "^14.0.2",
         "@octokit/core": "^5.0.0",
         "@octokit/oauth-app": "^6.0.0",
         "@octokit/plugin-paginate-graphql": "^4.0.0",
@@ -1753,9 +1753,9 @@
       }
     },
     "node_modules/@octokit/app": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.0.1.tgz",
-      "integrity": "sha512-4opdXcWBVhzd6FOxlaxDKXXqi9Vz2hsDSWQGNo49HbYFAX11UqMpksMjEdfvHy0x19Pse8Nvn+R6inNb/V398w==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.0.2.tgz",
+      "integrity": "sha512-NCSCktSx+XmjuSUVn2dLfqQ9WIYePGP95SDJs4I9cn/0ZkeXcPkaoCLl64Us3dRKL2ozC7hArwze5Eu+/qt1tg==",
       "dependencies": {
         "@octokit/auth-app": "^6.0.0",
         "@octokit/auth-unauthenticated": "^5.0.0",
@@ -1763,7 +1763,7 @@
         "@octokit/oauth-app": "^6.0.0",
         "@octokit/plugin-paginate-rest": "^9.0.0",
         "@octokit/types": "^12.0.0",
-        "@octokit/webhooks": "^12.0.1"
+        "@octokit/webhooks": "^12.0.4"
       },
       "engines": {
         "node": ">= 18"
@@ -2057,9 +2057,9 @@
       }
     },
     "node_modules/@octokit/webhooks": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.0.3.tgz",
-      "integrity": "sha512-8iG+/yza7hwz1RrQ7i7uGpK2/tuItZxZq1aTmeg2TNp2xTUB8F8lZF/FcZvyyAxT8tpDMF74TjFGCDACkf1kAQ==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.0.4.tgz",
+      "integrity": "sha512-dopyfA1suemLwlJsiEBKEW7hnVrxvk2xzXHkUkx68vl74ie9JzdizW6FUU0gVi3Bq3AVrIXS1Yt4vCF4KV5pqA==",
       "dependencies": {
         "@octokit/request-error": "^5.0.0",
         "@octokit/webhooks-methods": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals --esModuleInterop --strict test/typescript-validate.ts"
   },
   "dependencies": {
-    "@octokit/app": "^14.0.0",
+    "@octokit/app": "^14.0.2",
     "@octokit/core": "^5.0.0",
     "@octokit/oauth-app": "^6.0.0",
     "@octokit/plugin-paginate-graphql": "^4.0.0",


### PR DESCRIPTION
Relates to:
* https://github.com/octokit/app.js/pull/482
* https://github.com/octokit/webhooks.js/pull/914
* https://github.com/octokit/webhooks.js/pull/915
* https://github.com/octokit/webhooks.js/pull/916
* https://github.com/octokit/webhooks.js/pull/917

Fixes an issue where webhooks.js was throwing an error which could cause downstream problems.