### PR TITLE
refactor: use `node:` specifier imports and full relative path imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "prettier --write \"{src,test}/**/*.{js,json,ts}\" \"*.{md,json}\"",
     "pretest": "npm run -s lint",
     "test": "jest --coverage",
-    "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals --esModuleInterop --strict test/typescript-validate.ts"
+    "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals --esModuleInterop --strict --allowImportingTsExtensions test/typescript-validate.ts"
   },
   "dependencies": {
     "@octokit/app": "^14.0.2",
@@ -65,6 +65,9 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import esbuild from "esbuild";
-import { copyFile, readFile, writeFile, rm } from "fs/promises";
+import { copyFile, readFile, writeFile, rm } from "node:fs/promises";
 import { glob } from "glob";
 
 /**

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import { App as DefaultApp } from "@octokit/app";
 import { OAuthApp as DefaultOAuthApp } from "@octokit/oauth-app";
 
-import { Octokit } from "./octokit";
+import { Octokit } from "./octokit.js";
 
 export const App = DefaultApp.defaults({ Octokit });
 export type App = InstanceType<typeof App>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { Octokit, RequestError } from "./octokit";
-export type { PageInfoForward, PageInfoBackward } from "./octokit";
-export { App, OAuthApp, createNodeMiddleware } from "./app";
+export { Octokit, RequestError } from "./octokit.js";
+export type { PageInfoForward, PageInfoBackward } from "./octokit.js";
+export { App, OAuthApp, createNodeMiddleware } from "./app.js";

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -15,9 +15,6 @@ export type {
 } from "@octokit/plugin-paginate-graphql";
 
 export const Octokit = OctokitCore.plugin(
-  // There is a problem with TypeScript type hints when using the restEndpointMethods plugin along with the throttling plugin.
-  // It is safe to ignore.
-  // Using any method to make the "error" go away, will cause a real error in tests and the build.
   restEndpointMethods,
   paginateRest,
   paginateGraphql,

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:http";
 import fetchMock from "fetch-mock";
 import MockDate from "mockdate";
 
-import { App, Octokit, createNodeMiddleware } from "../src";
+import { App, Octokit, createNodeMiddleware } from "../src/index.ts";
 
 const APP_ID = 1;
 const PRIVATE_KEY = `-----BEGIN RSA PRIVATE KEY-----

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,4 +1,4 @@
-import { createServer } from "http";
+import { createServer } from "node:http";
 
 import fetchMock from "fetch-mock";
 import MockDate from "mockdate";

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,4 +1,4 @@
-import { Octokit, App, OAuthApp, RequestError } from "../src";
+import { Octokit, App, OAuthApp, RequestError } from "../src/index.ts";
 
 describe("Smoke tests", () => {
   it("Octokit is a function", () => {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -2,7 +2,7 @@
 // THIS CODE IS NOT EXECUTED. IT IS JUST FOR TYPECHECKING
 // ************************************************************
 
-import { App, OAuthApp, Octokit, RequestError } from "../src";
+import { App, OAuthApp, Octokit, RequestError } from "../src/index.ts";
 
 function expect<T>(what: T) {}
 


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.