### PR TITLE
docs(README): Missing required parameter issue_number

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,7 @@ app.webhooks.on("issues.opened", ({ octokit, payload }) => {
   return octokit.rest.issues.createComment({
     owner: payload.repository.owner.login,
     repo: payload.repository.name,
+    issue_number: payload.issue.number,
     body: "Hello, World!",
   });
 });


### PR DESCRIPTION
Resolves #2635 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Upon reviewing the README for the octokit.js library, I encountered an example in the webhooks section related to the `issues.createComment` method, but found that it was missing the required parameter `issue_number`, leading to confusion during implementation. 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* After suggesting the addition of the `issue_number` parameter to the example in the README for the `issues.createComment` method, clarity and usability of the documentation would be enhanced.

### Pull request checklist
N/A

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

