### PR TITLE
Update default OAuth web flow path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,7 +825,7 @@ app.oauth.on("token.created", async ({ token, octokit }) => {
 });
 
 // Your app can receive the OAuth redirect at /api/github/oauth/callback
-// Users can initiate the OAuth web flow by opening /api/oauth/login
+// Users can initiate the OAuth web flow by opening /api/github/oauth/login
 createServer(createNodeMiddleware(app)).listen(3000);
 ```
 


### PR DESCRIPTION
### Before the change?
*  The comment in the README indicates the wrong default path to initiate the OAuth web flow

### After the change?
*  The comment is updated to reflect the correct path

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

