### PR TITLE
feat(deps): bump Octokit deps to fix Deno compatibility, new endpoints via `@octokit/plugin-rest-endpoint-methods`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
         "@octokit/core": "^6.1.3",
         "@octokit/oauth-app": "^7.1.4",
         "@octokit/plugin-paginate-graphql": "^5.2.4",
-        "@octokit/plugin-paginate-rest": "^11.3.6",
-        "@octokit/plugin-rest-endpoint-methods": "^13.2.6",
+        "@octokit/plugin-paginate-rest": "^11.4.0",
+        "@octokit/plugin-rest-endpoint-methods": "^13.3.0",
         "@octokit/plugin-retry": "^7.1.3",
-        "@octokit/plugin-throttling": "^9.3.3",
+        "@octokit/plugin-throttling": "^9.4.0",
         "@octokit/request-error": "^6.1.6",
-        "@octokit/types": "^13.6.2"
+        "@octokit/types": "^13.7.0"
       },
       "devDependencies": {
         "@octokit/tsconfig": "^4.0.0",
@@ -809,9 +809,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
       "license": "MIT"
     },
     "node_modules/@octokit/openapi-webhooks-types": {
@@ -833,12 +833,12 @@
       }
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.6.tgz",
-      "integrity": "sha512-zcvqqf/+TicbTCa/Z+3w4eBJcAxCFymtc0UAIsR3dEVoNilWld4oXdscQ3laXamTszUZdusw97K8+DrbFiOwjw==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.0.tgz",
+      "integrity": "sha512-ttpGck5AYWkwMkMazNCZMqxKqIq1fJBNxBfsFwwfyYKTf914jKkLF0POMS3YkPBwp5g1c2Y4L79gDz01GhSr1g==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.6.2"
+        "@octokit/types": "^13.7.0"
       },
       "engines": {
         "node": ">= 18"
@@ -848,12 +848,12 @@
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "13.2.6",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.6.tgz",
-      "integrity": "sha512-wMsdyHMjSfKjGINkdGKki06VEkgdEldIGstIEyGX0wbYHGByOwN/KiM+hAAlUwAtPkP3gvXtVQA9L3ITdV2tVw==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.0.tgz",
+      "integrity": "sha512-LUm44shlmkp/6VC+qQgHl3W5vzUP99ZM54zH6BuqkJK4DqfFLhegANd+fM4YRLapTvPm4049iG7F3haANKMYvQ==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.6.1"
+        "@octokit/types": "^13.7.0"
       },
       "engines": {
         "node": ">= 18"
@@ -880,19 +880,19 @@
       }
     },
     "node_modules/@octokit/plugin-throttling": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.3.3.tgz",
-      "integrity": "sha512-UlBQ8T7kGzW471PUi0vi3rtXnAfp6sg5Gb13Y9YjKfjcMS1EHr4fLebqGJQo9Iw1ZHSLywg5oC0Oyu2QbNTTHw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.4.0.tgz",
+      "integrity": "sha512-IOlXxXhZA4Z3m0EEYtrrACkuHiArHLZ3CvqWwOez/pURNqRuwfoFlTPbN5Muf28pzFuztxPyiUiNwz8KctdZaQ==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.6.2",
+        "@octokit/types": "^13.7.0",
         "bottleneck": "^2.15.3"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": "^6.0.0"
+        "@octokit/core": "^6.1.3"
       }
     },
     "node_modules/@octokit/request": {
@@ -931,12 +931,12 @@
       "license": "MIT"
     },
     "node_modules/@octokit/types": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.2.tgz",
-      "integrity": "sha512-WpbZfZUcZU77DrSW4wbsSgTPfKcp286q3ItaIgvSbBpZJlu6mnYXAkjZz6LVZPXkEvLIM8McanyZejKTYUHipA==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.7.0.tgz",
+      "integrity": "sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^22.2.0"
+        "@octokit/openapi-types": "^23.0.1"
       }
     },
     "node_modules/@octokit/webhooks": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@octokit/app": "^15.1.1",
-        "@octokit/core": "^6.0.0",
-        "@octokit/oauth-app": "^7.0.0",
-        "@octokit/plugin-paginate-graphql": "^5.0.0",
-        "@octokit/plugin-paginate-rest": "^11.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^13.0.0",
-        "@octokit/plugin-retry": "^7.0.0",
-        "@octokit/plugin-throttling": "^9.0.0",
-        "@octokit/request-error": "^6.0.0",
+        "@octokit/app": "^15.1.2",
+        "@octokit/core": "^6.1.3",
+        "@octokit/oauth-app": "^7.1.4",
+        "@octokit/plugin-paginate-graphql": "^5.2.4",
+        "@octokit/plugin-paginate-rest": "^11.3.6",
+        "@octokit/plugin-rest-endpoint-methods": "^13.2.6",
+        "@octokit/plugin-retry": "^7.1.3",
+        "@octokit/plugin-throttling": "^9.3.3",
+        "@octokit/request-error": "^6.1.6",
         "@octokit/types": "^13.6.2"
       },
       "devDependencies": {
@@ -615,34 +615,34 @@
       }
     },
     "node_modules/@octokit/app": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-15.1.1.tgz",
-      "integrity": "sha512-fk8xrCSPTJGpyBdBNI+DcZ224dm0aApv4vi6X7/zTmANXlegKV2Td+dJ+fd7APPaPN7R+xttUsj2Fm+AFDSfMQ==",
+      "version": "15.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-15.1.2.tgz",
+      "integrity": "sha512-6aKmKvqnJKoVK+kx0mLlBMKmQYoziPw4Rd/PWr0j65QVQlrDXlu6hGU8fmTXt7tNkf/DsubdIaTT4fkoWzCh5g==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-app": "^7.0.0",
-        "@octokit/auth-unauthenticated": "^6.0.0",
-        "@octokit/core": "^6.1.2",
-        "@octokit/oauth-app": "^7.0.0",
-        "@octokit/plugin-paginate-rest": "^11.0.0",
-        "@octokit/types": "^13.0.0",
-        "@octokit/webhooks": "^13.0.0"
+        "@octokit/auth-app": "^7.1.4",
+        "@octokit/auth-unauthenticated": "^6.1.1",
+        "@octokit/core": "^6.1.3",
+        "@octokit/oauth-app": "^7.1.5",
+        "@octokit/plugin-paginate-rest": "^11.3.6",
+        "@octokit/types": "^13.6.2",
+        "@octokit/webhooks": "^13.4.2"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@octokit/auth-app": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-7.1.3.tgz",
-      "integrity": "sha512-GZdkOp2kZTIy5dG9oXqvzUAZiPvDx4C/lMlN6yQjtG9d/+hYa7W8WXTJoOrXE8UdfL9A/sZMl206dmtkl9lwVQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-7.1.4.tgz",
+      "integrity": "sha512-5F+3l/maq9JfWQ4bV28jT2G/K8eu9OJ317yzXPTGe4Kw+lKDhFaS4dQ3Ltmb6xImKxfCQdqDqMXODhc9YLipLw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-oauth-app": "^8.1.0",
-        "@octokit/auth-oauth-user": "^5.1.0",
-        "@octokit/request": "^9.1.1",
-        "@octokit/request-error": "^6.1.1",
-        "@octokit/types": "^13.4.1",
+        "@octokit/auth-oauth-app": "^8.1.2",
+        "@octokit/auth-oauth-user": "^5.1.2",
+        "@octokit/request": "^9.1.4",
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2",
         "toad-cache": "^3.7.0",
         "universal-github-app-jwt": "^2.2.0",
         "universal-user-agent": "^7.0.0"
@@ -652,15 +652,15 @@
       }
     },
     "node_modules/@octokit/auth-oauth-app": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-8.1.1.tgz",
-      "integrity": "sha512-5UtmxXAvU2wfcHIPPDWzVSAWXVJzG3NWsxb7zCFplCWEmMCArSZV0UQu5jw5goLQXbFyOr5onzEH37UJB3zQQg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-8.1.2.tgz",
+      "integrity": "sha512-3woNZgq5/S6RS+9ZTq+JdymxVr7E0s4EYxF20ugQvgX3pomdPUL5r/XdTY9wALoBM2eHVy4ettr5fKpatyTyHw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-oauth-device": "^7.0.0",
-        "@octokit/auth-oauth-user": "^5.0.1",
-        "@octokit/request": "^9.0.0",
-        "@octokit/types": "^13.0.0",
+        "@octokit/auth-oauth-device": "^7.1.2",
+        "@octokit/auth-oauth-user": "^5.1.2",
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
         "universal-user-agent": "^7.0.0"
       },
       "engines": {
@@ -683,15 +683,15 @@
       }
     },
     "node_modules/@octokit/auth-oauth-user": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-5.1.1.tgz",
-      "integrity": "sha512-rRkMz0ErOppdvEfnemHJXgZ9vTPhBuC6yASeFaB7I2yLMd7QpjfrL1mnvRPlyKo+M6eeLxrKanXJ9Qte29SRsw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-5.1.2.tgz",
+      "integrity": "sha512-PgVDDPJgZYb3qSEXK4moksA23tfn68zwSAsQKZ1uH6IV9IaNEYx35OXXI80STQaLYnmEE86AgU0tC1YkM4WjsA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-oauth-device": "^7.0.1",
-        "@octokit/oauth-methods": "^5.0.0",
-        "@octokit/request": "^9.0.1",
-        "@octokit/types": "^13.0.0",
+        "@octokit/auth-oauth-device": "^7.1.2",
+        "@octokit/oauth-methods": "^5.1.2",
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
         "universal-user-agent": "^7.0.0"
       },
       "engines": {
@@ -708,13 +708,13 @@
       }
     },
     "node_modules/@octokit/auth-unauthenticated": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-6.1.0.tgz",
-      "integrity": "sha512-zPSmfrUAcspZH/lOFQnVnvjQZsIvmfApQH6GzJrkIunDooU1Su2qt2FfMTSVPRp7WLTQyC20Kd55lF+mIYaohQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-6.1.1.tgz",
+      "integrity": "sha512-bGXqdN6RhSFHvpPq46SL8sN+F3odQ6oMNLWc875IgoqcC3qus+fOL2th6Tkl94wvdSTy8/OeHzWy/lZebmnhog==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/request-error": "^6.0.1",
-        "@octokit/types": "^13.0.0"
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2"
       },
       "engines": {
         "node": ">= 18"
@@ -766,17 +766,17 @@
       }
     },
     "node_modules/@octokit/oauth-app": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-7.1.4.tgz",
-      "integrity": "sha512-Au4zSGsWOZtShLxVUXcZ9TZJVQjpEK/OW2L1SWLE030QVYaZ+69TP4vHBdXakZUifvOELD1VBYEY6eprPcY2Mg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-7.1.5.tgz",
+      "integrity": "sha512-/Y2MiwWDlGUK4blKKfjJiwjzu/FzwKTTTfTZAAQ0QbdBIDEGJPWhOFH6muSN86zaa4tNheB4YS3oWIR2e4ydzA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-oauth-app": "^8.0.0",
-        "@octokit/auth-oauth-user": "^5.0.1",
-        "@octokit/auth-unauthenticated": "^6.0.0",
-        "@octokit/core": "^6.1.2",
-        "@octokit/oauth-authorization-url": "^7.0.0",
-        "@octokit/oauth-methods": "^5.0.0",
+        "@octokit/auth-oauth-app": "^8.1.2",
+        "@octokit/auth-oauth-user": "^5.1.2",
+        "@octokit/auth-unauthenticated": "^6.1.1",
+        "@octokit/core": "^6.1.3",
+        "@octokit/oauth-authorization-url": "^7.1.1",
+        "@octokit/oauth-methods": "^5.1.3",
         "@types/aws-lambda": "^8.10.83",
         "universal-user-agent": "^7.0.0"
       },
@@ -863,13 +863,13 @@
       }
     },
     "node_modules/@octokit/plugin-retry": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.1.2.tgz",
-      "integrity": "sha512-XOWnPpH2kJ5VTwozsxGurw+svB2e61aWlmk5EVIYZPwFK5F9h4cyPyj9CIKRyMXMHSwpIsI3mPOdpMmrRhe7UQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.1.3.tgz",
+      "integrity": "sha512-8nKOXvYWnzv89gSyIvgFHmCBAxfQAOPRlkacUHL9r5oWtp5Whxl8Skb2n3ACZd+X6cYijD6uvmrQuPH/UCL5zQ==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/request-error": "^6.0.0",
-        "@octokit/types": "^13.0.0",
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2",
         "bottleneck": "^2.15.3"
       },
       "engines": {
@@ -880,12 +880,12 @@
       }
     },
     "node_modules/@octokit/plugin-throttling": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.3.2.tgz",
-      "integrity": "sha512-FqpvcTpIWFpMMwIeSoypoJXysSAQ3R+ALJhXXSG1HTP3YZOIeLmcNcimKaXxTcws+Sh6yoRl13SJ5r8sXc1Fhw==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.3.3.tgz",
+      "integrity": "sha512-UlBQ8T7kGzW471PUi0vi3rtXnAfp6sg5Gb13Y9YjKfjcMS1EHr4fLebqGJQo9Iw1ZHSLywg5oC0Oyu2QbNTTHw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.0.0",
+        "@octokit/types": "^13.6.2",
         "bottleneck": "^2.15.3"
       },
       "engines": {
@@ -940,13 +940,13 @@
       }
     },
     "node_modules/@octokit/webhooks": {
-      "version": "13.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-13.4.1.tgz",
-      "integrity": "sha512-I5YPUtfWidh+OzyrlDahJsUpkpGK0kCTmDRbuqGmlCUzOtxdEkX3R4d6Cd08ijQYwkVXQJanPdbKuZBeV2NMaA==",
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-13.4.2.tgz",
+      "integrity": "sha512-fakbgkCScapQXPxyqx2jZs/Y3jGlyezwUp7ATL7oLAGJ0+SqBKWKstoKZpiQ+REeHutKpYjY9UtxdLSurwl2Tg==",
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-webhooks-types": "8.5.1",
-        "@octokit/request-error": "^6.0.1",
+        "@octokit/request-error": "^6.1.6",
         "@octokit/webhooks-methods": "^5.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "@octokit/core": "^6.1.3",
     "@octokit/oauth-app": "^7.1.4",
     "@octokit/plugin-paginate-graphql": "^5.2.4",
-    "@octokit/plugin-paginate-rest": "^11.3.6",
-    "@octokit/plugin-rest-endpoint-methods": "^13.2.6",
+    "@octokit/plugin-paginate-rest": "^11.4.0",
+    "@octokit/plugin-rest-endpoint-methods": "^13.3.0",
     "@octokit/plugin-retry": "^7.1.3",
-    "@octokit/plugin-throttling": "^9.3.3",
+    "@octokit/plugin-throttling": "^9.4.0",
     "@octokit/request-error": "^6.1.6",
-    "@octokit/types": "^13.6.2"
+    "@octokit/types": "^13.7.0"
   },
   "devDependencies": {
     "@octokit/tsconfig": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
     "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals --esModuleInterop --module node16 --strict --allowImportingTsExtensions --exactOptionalPropertyTypes test/typescript-validate.ts"
   },
   "dependencies": {
-    "@octokit/app": "^15.1.1",
-    "@octokit/core": "^6.0.0",
-    "@octokit/oauth-app": "^7.0.0",
-    "@octokit/plugin-paginate-graphql": "^5.0.0",
-    "@octokit/plugin-paginate-rest": "^11.0.0",
-    "@octokit/plugin-rest-endpoint-methods": "^13.0.0",
-    "@octokit/plugin-retry": "^7.0.0",
-    "@octokit/plugin-throttling": "^9.0.0",
-    "@octokit/request-error": "^6.0.0",
+    "@octokit/app": "^15.1.2",
+    "@octokit/core": "^6.1.3",
+    "@octokit/oauth-app": "^7.1.4",
+    "@octokit/plugin-paginate-graphql": "^5.2.4",
+    "@octokit/plugin-paginate-rest": "^11.3.6",
+    "@octokit/plugin-rest-endpoint-methods": "^13.2.6",
+    "@octokit/plugin-retry": "^7.1.3",
+    "@octokit/plugin-throttling": "^9.3.3",
+    "@octokit/request-error": "^6.1.6",
     "@octokit/types": "^13.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
See https://github.com/octokit/octokit.js/issues/2762#issuecomment-2486997620

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Types would include a reference to `@types/node` even though there is nothing using Node specific APIs in the types

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Update `@octokit/types` to make sure types are platform agnostic
* Update all Octokit dependencies to their latest version to ensure we pull in the latest version of `@octokit/types`

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

