### PR TITLE
Update clone instructions to use gh repo clone

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,12 @@ First, fork the repository.
 Set up the repository locally. Replace `<your account name>` with the name of the account you forked to and `<repository name>` with the repository name you forked.
 
 ```shell
-git clone https://github.com/<your account name>/<repository name>.git
+gh repo clone octokit/octokit.js
 cd <repository name>
 npm install
 ```
+
+For more information about the `gh` command-line tool, visit the [GitHub CLI documentation](https://cli.github.com/).
 
 Run the tests before making changes to make sure the local setup is working as expected
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ import { Octokit, App } from "octokit";
 ```
 
 </td></tr>
+<tr><th>
+GitHub CLI
+</th><td>
+
+Clone the repository using the `gh` command-line tool. Install the GitHub CLI from [here](https://cli.github.com/).
+
+```sh
+gh repo clone octokit/octokit.js
+```
+
+</td></tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
Add instructions for cloning the repository using `gh repo clone octokit/octokit.js` to the `README.md` and `CONTRIBUTING.md` files.

* **README.md**
  - Add a new section under "Usage" for cloning the repository using the `gh` command-line tool.
  - Provide a link to the GitHub CLI documentation.

* **CONTRIBUTING.md**
  - Update the instructions for setting up the repository locally to use `gh repo clone octokit/octokit.js` instead of `git clone`.
  - Provide a link to the GitHub CLI documentation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/octokit/octokit.js/pull/2793?shareId=45438525-6288-4547-927e-0468c2bcae11).