### PR TITLE
fix(deps): add explicit dependency on `@octokit/webhooks`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "@octokit/plugin-retry": "^7.2.1",
         "@octokit/plugin-throttling": "^10.0.0",
         "@octokit/request-error": "^6.1.8",
-        "@octokit/types": "^14.0.0"
+        "@octokit/types": "^14.0.0",
+        "@octokit/webhooks": "^13.8.3"
       },
       "devDependencies": {
         "@octokit/tsconfig": "^4.0.0",
@@ -818,9 +819,9 @@
       "license": "MIT"
     },
     "node_modules/@octokit/openapi-webhooks-types": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-10.4.0.tgz",
-      "integrity": "sha512-HMiF7FUiVBYfp8pPijMTkWuPELQB6XkPftrnSuK1C1YXaaq2+0ganiQkorEQfXTmhtwlgHJwXT6P8miVhIyjQA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-11.0.0.tgz",
+      "integrity": "sha512-ZBzCFj98v3SuRM7oBas6BHZMJRadlnDoeFfvm1olVxZnYeU6Vh97FhPxyS5aLh5pN51GYv2I51l/hVUAVkGBlA==",
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-graphql": {
@@ -943,12 +944,12 @@
       }
     },
     "node_modules/@octokit/webhooks": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-13.8.0.tgz",
-      "integrity": "sha512-3PCWyFBNbW2+Ox36VAkSqlPoIb96NZiPcICRYySHZrDTM2NuNxvrjPeaQDj2egqILs9EZFObRTHVMe4XxXJV7w==",
+      "version": "13.8.3",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-13.8.3.tgz",
+      "integrity": "sha512-BAbh56HPe+OGrpl7PLrgTTnImep+fjrDiuFMl4D3tQOAQaqZxW0bTtsAcSmusBvw8WY7GYSjNV8vkvpAwazKgg==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-webhooks-types": "10.4.0",
+        "@octokit/openapi-webhooks-types": "11.0.0",
         "@octokit/request-error": "^6.1.7",
         "@octokit/webhooks-methods": "^5.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "@octokit/plugin-retry": "^7.2.1",
     "@octokit/plugin-throttling": "^10.0.0",
     "@octokit/request-error": "^6.1.8",
-    "@octokit/types": "^14.0.0"
+    "@octokit/types": "^14.0.0",
+    "@octokit/webhooks": "^13.8.3"
   },
   "devDependencies": {
     "@octokit/tsconfig": "^4.0.0",


### PR DESCRIPTION
Because of the way that the types are defined, the `App` class definition created with `App#defaults()` contains references to `@octokit/webhooks`.

Adds an explicit dependency on `@octokit/webhooks` to avoid any issue for consumers.

Fixes #2844

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

